### PR TITLE
PWM module implementation. 

### DIFF
--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -123,6 +123,7 @@ endif
 DRIVERS_SRC_C += $(addprefix drivers/,\
 	machine/psoc6_gpio.c \
 	machine/psoc6_i2c.c \
+	machine/psoc6_pwm.c \
 	machine/psoc6_system.c  \
 	)
 
@@ -133,6 +134,7 @@ MOD_SRC_C += $(addprefix modules/,\
 	machine/machine_i2c.c \
 	machine/machine_pin.c \
 	machine/machine_rtc.c \
+	machine/machine_pwm.c \
 	machine/pins.c \
 	\
 	psoc6/modpsoc6.c \

--- a/ports/psoc6/drivers/machine/psoc6_pwm.c
+++ b/ports/psoc6/drivers/machine/psoc6_pwm.c
@@ -5,7 +5,7 @@
 #include "psoc6_pwm.h"
 
 cy_rslt_t pwm_freq_duty_set(cyhal_pwm_t *pwm_obj, uint32_t fz, float duty_cycle) {
-    return cyhal_pwm_set_duty_cycle(pwm_obj, duty_cycle, fz);
+    return cyhal_pwm_set_duty_cycle(pwm_obj, duty_cycle * 100, fz); // duty_cycle in percentage
 }
 
 cy_rslt_t pwm_start(cyhal_pwm_t *pwm_obj) {
@@ -22,4 +22,8 @@ void pwm_deinit(cyhal_pwm_t *pwm_obj) {
 
 cy_rslt_t pwm_duty_set_ns(cyhal_pwm_t *pwm_obj, uint32_t fz, uint32_t pulse_width) {
     return cyhal_pwm_set_period(pwm_obj, 1000000 / fz, pulse_width * 1000);
+}
+
+cy_rslt_t pwm_advanced_init(machine_pwm_obj_t *machine_pwm_obj) {
+    return cyhal_pwm_init_adv(&machine_pwm_obj->pwm_obj, machine_pwm_obj->pin, NC, CYHAL_PWM_LEFT_ALIGN, true, 0, true, NULL);
 }

--- a/ports/psoc6/drivers/machine/psoc6_pwm.c
+++ b/ports/psoc6/drivers/machine/psoc6_pwm.c
@@ -1,0 +1,25 @@
+// MTB includes
+#include "cyhal.h"
+
+// port-specific includes
+#include "psoc6_pwm.h"
+
+cy_rslt_t pwm_freq_duty_set(cyhal_pwm_t *pwm_obj, uint32_t fz, float duty_cycle) {
+    return cyhal_pwm_set_duty_cycle(pwm_obj, duty_cycle, fz);
+}
+
+cy_rslt_t pwm_start(cyhal_pwm_t *pwm_obj) {
+    return cyhal_pwm_start(pwm_obj);
+}
+
+cy_rslt_t pwm_init(machine_pwm_obj_t *machine_pwm_obj) {
+    return cyhal_pwm_init(&machine_pwm_obj->pwm_obj, machine_pwm_obj->pin, NULL);
+}
+
+void pwm_deinit(cyhal_pwm_t *pwm_obj) {
+    cyhal_pwm_free(pwm_obj);
+}
+
+cy_rslt_t pwm_duty_set_ns(cyhal_pwm_t *pwm_obj, uint32_t fz, uint32_t pulse_width) {
+    return cyhal_pwm_set_period(pwm_obj, 1000000 / fz, pulse_width * 1000);
+}

--- a/ports/psoc6/drivers/machine/psoc6_pwm.c
+++ b/ports/psoc6/drivers/machine/psoc6_pwm.c
@@ -25,5 +25,5 @@ cy_rslt_t pwm_duty_set_ns(cyhal_pwm_t *pwm_obj, uint32_t fz, uint32_t pulse_widt
 }
 
 cy_rslt_t pwm_advanced_init(machine_pwm_obj_t *machine_pwm_obj) {
-    return cyhal_pwm_init_adv(&machine_pwm_obj->pwm_obj, machine_pwm_obj->pin, NC, CYHAL_PWM_LEFT_ALIGN, true, 0, true, NULL);
+    return cyhal_pwm_init_adv(&machine_pwm_obj->pwm_obj, machine_pwm_obj->pin, NC, CYHAL_PWM_LEFT_ALIGN, true, 0, true, NULL); // complimentary pin set as not connected
 }

--- a/ports/psoc6/drivers/machine/psoc6_pwm.h
+++ b/ports/psoc6/drivers/machine/psoc6_pwm.h
@@ -10,10 +10,11 @@
 typedef struct _machine_pwm_obj_t {
     mp_obj_base_t base;
     cyhal_pwm_t pwm_obj;
+    bool active;
     uint8_t pin;
     uint32_t fz;
-    float duty_us;
-    uint32_t duty_ns;
+    uint8_t duty_type;
+    mp_float_t duty;
     bool invert;
 } machine_pwm_obj_t;
 
@@ -22,5 +23,6 @@ cy_rslt_t pwm_start(cyhal_pwm_t *pwm_obj);
 cy_rslt_t pwm_init(machine_pwm_obj_t *machine_pwm_obj);
 cy_rslt_t pwm_duty_set_ns(cyhal_pwm_t *pwm_obj, uint32_t fz, uint32_t pulse_width);
 void pwm_deinit(cyhal_pwm_t *pwm_obj);
+cy_rslt_t pwm_advanced_init(machine_pwm_obj_t *machine_pwm_obj);
 
 #endif // MICROPY_INCLUDED_PSOC6_PWM_H

--- a/ports/psoc6/drivers/machine/psoc6_pwm.h
+++ b/ports/psoc6/drivers/machine/psoc6_pwm.h
@@ -22,7 +22,7 @@ cy_rslt_t pwm_freq_duty_set(cyhal_pwm_t *pwm_obj, uint32_t fz, float duty_cycle)
 cy_rslt_t pwm_start(cyhal_pwm_t *pwm_obj);
 cy_rslt_t pwm_init(machine_pwm_obj_t *machine_pwm_obj);
 cy_rslt_t pwm_duty_set_ns(cyhal_pwm_t *pwm_obj, uint32_t fz, uint32_t pulse_width);
-void pwm_deinit(cyhal_pwm_t *pwm_obj);
 cy_rslt_t pwm_advanced_init(machine_pwm_obj_t *machine_pwm_obj);
+void pwm_deinit(cyhal_pwm_t *pwm_obj);
 
 #endif // MICROPY_INCLUDED_PSOC6_PWM_H

--- a/ports/psoc6/drivers/machine/psoc6_pwm.h
+++ b/ports/psoc6/drivers/machine/psoc6_pwm.h
@@ -1,0 +1,26 @@
+#ifndef MICROPY_INCLUDED_PSOC6_PWM_H
+#define MICROPY_INCLUDED_PSOC6_PWM_H
+
+// mpy includes
+#include "py/runtime.h"
+
+// MTB includes
+#include "cyhal.h"
+
+typedef struct _machine_pwm_obj_t {
+    mp_obj_base_t base;
+    cyhal_pwm_t pwm_obj;
+    uint8_t pin;
+    uint32_t fz;
+    float duty_us;
+    uint32_t duty_ns;
+    bool invert;
+} machine_pwm_obj_t;
+
+cy_rslt_t pwm_freq_duty_set(cyhal_pwm_t *pwm_obj, uint32_t fz, float duty_cycle);
+cy_rslt_t pwm_start(cyhal_pwm_t *pwm_obj);
+cy_rslt_t pwm_init(machine_pwm_obj_t *machine_pwm_obj);
+cy_rslt_t pwm_duty_set_ns(cyhal_pwm_t *pwm_obj, uint32_t fz, uint32_t pulse_width);
+void pwm_deinit(cyhal_pwm_t *pwm_obj);
+
+#endif // MICROPY_INCLUDED_PSOC6_PWM_H

--- a/ports/psoc6/modules/machine/machine_pwm.c
+++ b/ports/psoc6/modules/machine/machine_pwm.c
@@ -10,11 +10,28 @@
 
 extern mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj);
 
-#define VALUE_NOT_SET -1
+enum {
+    VALUE_NOT_SET = -1,
+    DUTY_NOT_SET = 0,
+    DUTY_U16,
+    DUTY_NS
+};
+
+STATIC void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq);
+STATIC void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_float_t duty_u16);
+STATIC void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_float_t duty_ns);
+
+// To check whether the PWM is active
+STATIC void pwm_is_active(machine_pwm_obj_t *self) {
+    if (self->active == 0) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("PWM inactive"));
+    }
+}
 
 STATIC void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "frequency=%u duty_cycle_us=%f invert=%u", self->fz, self->duty_us, self->invert);
+    pwm_is_active(self_in);
+    mp_printf(print, "frequency=%u duty_cycle=%f invert=%u", self->fz, self->duty, self->invert);
 }
 
 STATIC void mp_machine_pwm_init_helper(machine_pwm_obj_t *self,
@@ -31,25 +48,37 @@ STATIC void mp_machine_pwm_init_helper(machine_pwm_obj_t *self,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args,
         MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    self->active = 1;
 
     if ((args[ARG_freq].u_int != VALUE_NOT_SET)) {
-        pwm_freq_duty_set(&self->pwm_obj, args[ARG_freq].u_int, self->duty_us);
+        pwm_freq_duty_set(&self->pwm_obj, args[ARG_freq].u_int, self->duty);
         self->fz = args[ARG_freq].u_int;
-
     }
 
     if ((args[ARG_duty_u16].u_int != VALUE_NOT_SET)) {
-        pwm_freq_duty_set(&self->pwm_obj, self->fz, args[ARG_duty_u16].u_int * 100 / 65536);
-        self->duty_us = args[ARG_duty_u16].u_int * 100 / 65536;
+        pwm_freq_duty_set(&self->pwm_obj, self->fz, args[ARG_duty_u16].u_int / 65535);
+        self->duty = args[ARG_duty_u16].u_int;
+        self->duty_type = DUTY_U16;
     }
 
     if (args[ARG_duty_ns].u_int != VALUE_NOT_SET) {
         pwm_duty_set_ns(&self->pwm_obj, self->fz, args[ARG_duty_ns].u_int);
-        self->duty_ns = args[ARG_duty_ns].u_int;
+        self->duty = args[ARG_duty_ns].u_int;
+        self->duty_type = DUTY_NS;
     }
 
+    // inverts the respective output if the value is True
     if (args[ARG_invert].u_int != VALUE_NOT_SET) {
-        self->invert = !!args[ARG_invert].u_int;
+        self->invert = args[ARG_invert].u_int;
+        if (self->invert == 1) {
+            pwm_deinit(&self->pwm_obj);
+            cy_rslt_t result = pwm_advanced_init(self);
+            if (result != CY_RSLT_SUCCESS) {
+                mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM initialisation failed with return code %lx ! and invert output is not available"), result);
+            }
+            self->duty_type = DUTY_U16;
+            self->duty = ((1) - ((self->duty) / 65535)) * 65535;
+        }
     }
     pwm_start(&self->pwm_obj);
 }
@@ -65,10 +94,14 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
     self->base.type = &machine_pwm_type;
     self->pin = pin;
+    self->active = 0;
+    self->duty_type = DUTY_NOT_SET;
+    self->fz = -1;
+    self->invert = -1;
 
     // Initialize PWM
     cy_rslt_t result = pwm_init(self);
-
+    // To check whether PWM init is successfull
     if (result != CY_RSLT_SUCCESS) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM initialisation failed with return code %lx !"), result);
     }
@@ -83,36 +116,61 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 
 STATIC void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
     pwm_deinit(&self->pwm_obj);
+    self->active = 0;
 }
 
+
 STATIC mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
-    // How to check whether PWM is active?
+    pwm_is_active(self);
     return MP_OBJ_NEW_SMALL_INT(self->fz);
 
 }
 
 STATIC void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
+    pwm_is_active(self);
     self->fz = freq;
-    pwm_freq_duty_set(&self->pwm_obj, freq, self->duty_us);
+    pwm_freq_duty_set(&self->pwm_obj, freq, self->duty);
+    if (self->duty_type == DUTY_NS) {
+        self->duty = ((self->duty) * (self->fz) * 65535) / 1000000000;
+        mp_machine_pwm_duty_set_ns(self, self->duty);
+    }
 }
 
 STATIC mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
-    return MP_OBJ_NEW_SMALL_INT(self->duty_us);
+    pwm_is_active(self);
+    if (self->duty_type == DUTY_NS) {
+        // duty_cycle = pulsewidth(ns)*freq(hz);
+        return mp_obj_new_float(((self->duty) * (self->fz) * 65535) / 1000000000);
+    } else {
+        return mp_obj_new_float(self->duty);
+    }
 }
 
-STATIC void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
+// sets the duty cycle as a ratio duty_u16 / 65535.
+STATIC void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_float_t duty_u16) {
+    pwm_is_active(self);
+    // Check the value is more than the max value
     if (duty_u16 > 65535) {
         duty_u16 = 65535;
     }
-    self->duty_us = duty_u16 * 100 / 65536;
-    pwm_freq_duty_set(&self->pwm_obj, self->fz, duty_u16 * 100 / 65536);
+    self->duty = duty_u16;
+    self->duty_type = DUTY_U16;
+    pwm_freq_duty_set(&self->pwm_obj, self->fz, (self->duty) / 65535); // conversion of duty_u16 into dutyu16/65535
 }
 
 STATIC mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
-    return MP_OBJ_NEW_SMALL_INT(self->duty_ns);
+    pwm_is_active(self);
+    if (self->duty_type == DUTY_U16) {
+        return mp_obj_new_float(((self->duty) * 1000000000) / ((self->fz) * 65535));   // pw (ns) = duty_cycle*10^9/fz
+    } else {
+        return mp_obj_new_float(self->duty);
+    }
 }
 
-STATIC void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
-    self->duty_ns = duty_ns;
+// sets the pulse width in nanoseconds
+STATIC void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_float_t duty_ns) {
+    pwm_is_active(self);
+    self->duty = duty_ns;
+    self->duty_type = DUTY_NS;
     pwm_freq_duty_set(&self->pwm_obj, self->fz, duty_ns);
 }

--- a/ports/psoc6/modules/machine/machine_pwm.c
+++ b/ports/psoc6/modules/machine/machine_pwm.c
@@ -14,7 +14,7 @@ extern mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj);
 
 STATIC void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "frequency=%u duty_cycle=%f invert=%u>", self->fz, self->duty_us, self->invert);
+    mp_printf(print, "frequency=%u duty_cycle_us=%f invert=%u", self->fz, self->duty_us, self->invert);
 }
 
 STATIC void mp_machine_pwm_init_helper(machine_pwm_obj_t *self,

--- a/ports/psoc6/modules/machine/machine_pwm.c
+++ b/ports/psoc6/modules/machine/machine_pwm.c
@@ -151,10 +151,7 @@ STATIC mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
 STATIC void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_float_t duty_u16) {
     pwm_is_active(self);
     // Check the value is more than the max value
-    if (duty_u16 > 65535) {
-        duty_u16 = 65535;
-    }
-    self->duty = duty_u16;
+    self->duty = duty_u16 > 65535 ? 65535 : duty_u16;
     self->duty_type = DUTY_U16;
     pwm_freq_duty_set(&self->pwm_obj, self->fz, (self->duty) / 65535); // conversion of duty_u16 into dutyu16/65535
 }

--- a/ports/psoc6/modules/machine/machine_pwm.c
+++ b/ports/psoc6/modules/machine/machine_pwm.c
@@ -1,0 +1,118 @@
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "modmachine.h"
+
+// port-specific includes
+#include "drivers/machine/psoc6_gpio.h"
+#include "drivers/machine/psoc6_pwm.h"
+#include "mplogger.h"
+#include "pins.h"
+
+extern mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj);
+
+#define VALUE_NOT_SET -1
+
+STATIC void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "frequency=%u duty_cycle=%f invert=%u>", self->fz, self->duty_us, self->invert);
+}
+
+STATIC void mp_machine_pwm_init_helper(machine_pwm_obj_t *self,
+    size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_freq, ARG_duty_u16, ARG_duty_ns, ARG_invert };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_freq,     MP_ARG_INT, {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_duty_u16, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_duty_ns,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_invert,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = VALUE_NOT_SET} },
+    };
+
+    // Parse the arguments.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args,
+        MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if ((args[ARG_freq].u_int != VALUE_NOT_SET)) {
+        pwm_freq_duty_set(&self->pwm_obj, args[ARG_freq].u_int, self->duty_us);
+        self->fz = args[ARG_freq].u_int;
+
+    }
+
+    if ((args[ARG_duty_u16].u_int != VALUE_NOT_SET)) {
+        pwm_freq_duty_set(&self->pwm_obj, self->fz, args[ARG_duty_u16].u_int * 100 / 65536);
+        self->duty_us = args[ARG_duty_u16].u_int * 100 / 65536;
+    }
+
+    if (args[ARG_duty_ns].u_int != VALUE_NOT_SET) {
+        pwm_duty_set_ns(&self->pwm_obj, self->fz, args[ARG_duty_ns].u_int);
+        self->duty_ns = args[ARG_duty_ns].u_int;
+    }
+
+    if (args[ARG_invert].u_int != VALUE_NOT_SET) {
+        self->invert = !!args[ARG_invert].u_int;
+    }
+    pwm_start(&self->pwm_obj);
+}
+
+STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    // Check number of arguments
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    // Get GPIO to connect to PWM.
+    int pin = mp_hal_get_pin_obj(all_args[0]);
+
+    // Get static peripheral object.
+    machine_pwm_obj_t *self = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
+    self->base.type = &machine_pwm_type;
+    self->pin = pin;
+
+    // Initialize PWM
+    cy_rslt_t result = pwm_init(self);
+
+    if (result != CY_RSLT_SUCCESS) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM initialisation failed with return code %lx !"), result);
+    }
+
+    // Process the remaining parameters.
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, all_args + n_args);
+    mp_machine_pwm_init_helper(self, n_args - 1, all_args + 1, &kw_args);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
+    pwm_deinit(&self->pwm_obj);
+}
+
+STATIC mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
+    // How to check whether PWM is active?
+    return MP_OBJ_NEW_SMALL_INT(self->fz);
+
+}
+
+STATIC void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
+    self->fz = freq;
+    pwm_freq_duty_set(&self->pwm_obj, freq, self->duty_us);
+}
+
+STATIC mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
+    return MP_OBJ_NEW_SMALL_INT(self->duty_us);
+}
+
+STATIC void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
+    if (duty_u16 > 65535) {
+        duty_u16 = 65535;
+    }
+    self->duty_us = duty_u16 * 100 / 65536;
+    pwm_freq_duty_set(&self->pwm_obj, self->fz, duty_u16 * 100 / 65536);
+}
+
+STATIC mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
+    return MP_OBJ_NEW_SMALL_INT(self->duty_ns);
+}
+
+STATIC void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
+    self->duty_ns = duty_ns;
+    pwm_freq_duty_set(&self->pwm_obj, self->fz, duty_ns);
+}

--- a/ports/psoc6/modules/machine/machine_pwm.c
+++ b/ports/psoc6/modules/machine/machine_pwm.c
@@ -102,7 +102,7 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     // Initialize PWM
     cy_rslt_t result = pwm_init(self);
 
-    // To check whether PWM init is successfull
+    // To check whether PWM init is successful
     if (result != CY_RSLT_SUCCESS) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM initialisation failed with return code %lx !"), result);
     }

--- a/ports/psoc6/modules/machine/machine_pwm.c
+++ b/ports/psoc6/modules/machine/machine_pwm.c
@@ -101,6 +101,7 @@ STATIC mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 
     // Initialize PWM
     cy_rslt_t result = pwm_init(self);
+
     // To check whether PWM init is successfull
     if (result != CY_RSLT_SUCCESS) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM initialisation failed with return code %lx !"), result);

--- a/ports/psoc6/modules/machine/modmachine.c
+++ b/ports/psoc6/modules/machine/modmachine.c
@@ -258,7 +258,8 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2C),                 MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SoftI2C),             MP_ROM_PTR(&mp_machine_soft_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_Pin),                 MP_ROM_PTR(&machine_pin_type) },
-    { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }
+    { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) },
+    { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) },
 };
 STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
 

--- a/ports/psoc6/modules/machine/modmachine.h
+++ b/ports/psoc6/modules/machine/modmachine.h
@@ -9,7 +9,7 @@
 extern const mp_obj_type_t machine_i2c_type;
 extern const mp_obj_type_t machine_pin_type;
 extern const mp_obj_type_t machine_rtc_type;
-
+extern const mp_obj_type_t machine_pwm_type;
 
 /* Note: the static functions' prototypes in the .c file cannot be declared here
 since they are static. The static type in those functions come from MPY hence

--- a/ports/psoc6/mpconfigport.h
+++ b/ports/psoc6/mpconfigport.h
@@ -113,8 +113,8 @@
 
 #define MICROPY_PY_MACHINE                      (1)
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW         mp_pin_make_new
-#define MICROPY_PY_MACHINE_PWM                  (0)
-#define MICROPY_PY_MACHINE_PWM_DUTY_U16_NS      (0)
+#define MICROPY_PY_MACHINE_PWM                  (1)
+#define MICROPY_PY_MACHINE_PWM_INCLUDEFILE      "ports/psoc6/modules/machine/machine_pwm.c"
 #define MICROPY_PY_MACHINE_I2C                  (1)
 #define MICROPY_PY_MACHINE_SOFTI2C              (1)
 
@@ -130,7 +130,6 @@
 // set to 1 to enable filesystem to be loaded on external qspi flash
 // if set to 0, filesystem is located in an allotted area of internal flash of PSoC6
 #define MICROPY_ENABLE_EXT_QSPI_FLASH               (1)
-
 
 #define MICROPY_PY_UCRYPTOLIB                   (1)
 #define MICROPY_PY_UCRYPTOLIB_CTR               (1)

--- a/tests/psoc6/pwm.py
+++ b/tests/psoc6/pwm.py
@@ -1,7 +1,7 @@
 ### PWM
 from machine import PWM
 
-pwm = PWM("P13_7", freq=50, duty_u16=8192, invert=0)
+pwm = PWM("P9_0", freq=50, duty_u16=8192, invert=0)
 print(pwm)
 print(pwm.freq())
 print(pwm.duty_u16())

--- a/tests/psoc6/pwm.py
+++ b/tests/psoc6/pwm.py
@@ -1,7 +1,9 @@
 ### PWM
 from machine import PWM
 
-pwm = PWM("P13_7", freq=2, duty_us=32678)
+pwm = PWM("P13_7", freq=50, duty_u16=8192, invert=0)
 print(pwm)
-pwm.freq()
-pwm.duty_16()
+print(pwm.freq())
+print(pwm.duty_u16())
+pwm.duty_ns(1000)
+print(pwm.duty_ns())

--- a/tests/psoc6/pwm.py
+++ b/tests/psoc6/pwm.py
@@ -1,0 +1,7 @@
+### PWM
+from machine import PWM
+
+pwm = PWM("P13_7", freq=2, duty_us=32678)
+print(pwm)
+pwm.freq()
+pwm.duty_16()

--- a/tests/psoc6/pwm.py.exp
+++ b/tests/psoc6/pwm.py.exp
@@ -1,0 +1,4 @@
+frequency=2 duty_cycle=50.000000 invert=0
+2
+50.000000
+1000

--- a/tests/psoc6/pwm.py.exp
+++ b/tests/psoc6/pwm.py.exp
@@ -1,4 +1,4 @@
-frequency=2 duty_cycle=50.000000 invert=0
-2
-50.000000
-1000
+frequency=50 duty_cycle=8192.000000 invert=0
+50
+8192.0
+1000.0


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description

There is an existing extmod for PWM & it demands the implementation of certain functions in the port. Corresponding macros are enabled & required functions are implemented. cy_hal is used & since it's not having the functions to return the current duty cycle, frequency or pulse width then standard formulas are used to calculate the current values in corresponding functions & variables are used to store them. 