### PR TITLE
Ext flash erase

### DIFF
--- a/.github/workflows/ports_psoc6.yml
+++ b/.github/workflows/ports_psoc6.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         cd tools/psoc6
         cp ../../mpy-psoc6_${{ matrix.board }}_${{ needs.server-build.outputs.commit_sha }}/firmware.hex .
-        source mpy-psoc6.sh && openocd_download_install && mpy_firmware_deploy ${{ matrix.board }} firmware.hex
+        source mpy-psoc6.sh && openocd_download_install && openocd_board_conf_download ${{ matrix.board }} && mpy_firmware_deploy ${{ matrix.board }} firmware.hex
         cd ../..
     - name: Run tests
       run: cd tests && ./run-tests.py --target psoc6 --device /dev/ttyACM0 -d psoc6

--- a/docs/psoc6/installation.rst
+++ b/docs/psoc6/installation.rst
@@ -159,6 +159,31 @@ The board needs to be specified, and the path and name of the ``.hex`` file:
                 
                 mpy-psoc6.cmd firmware-deploy CY8CPROTO-062-4343W pathtodir/mpy-psoc6_CY8CPROTO-062-4343W.hex
 
+Erasing the device (external) file system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some PSoC6™ boards include an external flash memory which is used by the MicroPython file system. This memory will not be erased when
+reprogramming or erasing MicroPython firmware via ``device-setup`` or ``firmware-deploy``.
+Use the ``device-erase`` command to erase of the external memory of your PSoC6™ device:
+
+.. tabs::
+
+    .. group-tab:: Linux
+        
+            .. code-block:: bash
+
+                ./mpy-psoc6.sh device-erase
+
+    .. group-tab:: Windows
+
+            .. code-block:: bash
+                
+                mpy-psoc6.cmd device-erase
+
+.. warning::
+    
+    This command flashes the PSoC6™ controller with a custom program to delete the external memory. Thus, MicroPython will be removed from the
+    microcontroller. Use any of the script commands described above to reinstall MicroPython. 
 
 Getting the firmware
 ^^^^^^^^^^^^^^^^^^^^

--- a/ports/psoc6/boards/CY8CPROTO-062-4343W/makefile_mtb.mk
+++ b/ports/psoc6/boards/CY8CPROTO-062-4343W/makefile_mtb.mk
@@ -80,7 +80,7 @@ mpy_program: $(MPY_MAIN_BUILD_DIR)/firmware.hex
 	@:
 	$(info )
 	$(info Programming using openocd ...)
-	$(OPENOCD_HOME)/bin/openocd -s $(OPENOCD_HOME)/scripts -s bsps/TARGET_APP_CY8CPROTO-062-4343W/config/GeneratedSource -c "source [find interface/kitprog3.cfg]; $(SERIAL_ADAPTER_CMD) ; source [find target/psoc6_2m.cfg]; psoc6 allow_efuse_program off; psoc6 sflash_restrictions 1; program $(MPY_DIR_OF_MAIN_MAKEFILE)/build/firmware.hex verify reset exit;"
+	$(OPENOCD_HOME)/bin/openocd -s $(OPENOCD_HOME)/scripts -s $(MPY_DIR_OF_MTB_ADAPTER_MAKEFILE)/bsps/TARGET_APP_CY8CPROTO-062-4343W/config/GeneratedSource -c "source [find interface/kitprog3.cfg]; $(SERIAL_ADAPTER_CMD) ; source [find target/psoc6_2m.cfg]; psoc6 allow_efuse_program off; psoc6 sflash_restrictions 1; program $(MPY_DIR_OF_MAIN_MAKEFILE)/build/firmware.hex verify reset exit;"
 	$(info Programming done.)
 
 # Use this target to program multiple attached target devices


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
* Added command to erase external flash.
* Added the openocd bsp configuration to flashing process. This could resolve the issues with new boards. If that is the case, we can delete the stage of flashing the hello-world. But first needs testing.