### PR TITLE
ports/psoc6: Adding code for machine.Signal functionality.

### DIFF
--- a/docs/psoc6/quickref.rst
+++ b/docs/psoc6/quickref.rst
@@ -146,6 +146,9 @@ The following constants are used to configure the pin objects in addition to the
           
     Selects the pin value.
 
+There's a higher-level abstraction :ref:`machine.Signal <machine.Signal>`
+which can be used to invert a pin. Useful for illuminating active-low LEDs
+using ``on()`` or ``value(1)``.
 
 Software I2C bus
 ----------------

--- a/ports/psoc6/modules/machine/machine_pin.c
+++ b/ports/psoc6/modules/machine/machine_pin.c
@@ -7,6 +7,7 @@
 #include "modmachine.h"
 #include "drivers/machine/psoc6_gpio.h"
 #include "pins.h"
+#include "extmod/virtpin.h"
 #include "mplogger.h"
 
 
@@ -326,6 +327,25 @@ STATIC const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
 };
 STATIC MP_DEFINE_CONST_DICT(machine_pin_locals_dict, machine_pin_locals_dict_table);
 
+STATIC mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    (void)errcode;
+    machine_pin_obj_t *self = self_in;
+    switch (request) {
+        case MP_PIN_READ: {
+            return cyhal_gpio_read(self->pin_addr);
+        }
+        case MP_PIN_WRITE: {
+            cyhal_gpio_write(self->pin_addr, arg);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+STATIC const mp_pin_p_t pin_pin_p = {
+    .ioctl = pin_ioctl,
+};
+
 MP_DEFINE_CONST_OBJ_TYPE(
     machine_pin_type,
     MP_QSTR_Pin,
@@ -333,5 +353,6 @@ MP_DEFINE_CONST_OBJ_TYPE(
     make_new, mp_pin_make_new,
     print, machine_pin_print,
     call, machine_pin_call,
+    protocol, &pin_pin_p,
     locals_dict, &machine_pin_locals_dict
     );

--- a/ports/psoc6/modules/machine/modmachine.c
+++ b/ports/psoc6/modules/machine/modmachine.c
@@ -258,6 +258,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2C),                 MP_ROM_PTR(&machine_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SoftI2C),             MP_ROM_PTR(&mp_machine_soft_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_Pin),                 MP_ROM_PTR(&machine_pin_type) },
+    { MP_ROM_QSTR(MP_QSTR_Signal),              MP_ROM_PTR(&machine_signal_type) },
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) },
     { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_spi_type) },


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
- Enables Signal module and available functions work.
- Ideally, I would have wanted to reuse the APIs in driver but hal apis were more promising.
- The tests/extmod/machine_signal.py should be passed but there are two problems:
1. It depends on machine.PinBase which is another extmod extended by MPY but needs to enabled in our port.
2. The value() is not used as it is mentioned [here](https://ifx-micropython.readthedocs.io/en/latest/library/machine.Pin.html#machine-pin). The guide says value() returns undefined value which is how we implement in our por,t but the tests by mpy assume they return the digital value on that pin. Hence this test might not be useful even if we enable it.