### PR TITLE
Fix of scheduler & Machine class interrupt function implementation

### DIFF
--- a/docs/psoc6/feature_list.rst
+++ b/docs/psoc6/feature_list.rst
@@ -105,10 +105,10 @@ Table :ref:`configuration details <table_mpy_configuration>` below lists specifi
 |                 | Submodules/classes not yet implemented: *ADC*, *bitstream*, *mem*, *Signal*, *SD*, *SDCard*, *SoftSPI*, *SPI*,       |
 |                 | *Timer*, *UART*, *WDT*.                                                                                              |
 +-----------------+----------------------------------------------------------------------------------------------------------------------+
-| machine.Pin     | Functions not yet implemented: *drive()*, *irq()*, *mode()*, *pull()*.                                               |
+| machine.Pin     | Functions not yet implemented: *drive()*, *mode()*, *pull()*.                                                        |
 |                 |                                                                                                                      |
 |                 | Constants not yet implemented: *ALT*, *ALT_OPEN_DRAIN*, *PULL_UP*, *PULL_DOWN*, *PULL_HOLD*, *LOW_POWER*,            |
-|                 | *MED_POWER*, *HIGH_POWER*, *IRQ_FALLING*, *IRQ_RISING*, *IRQ_LOW_LEVEL*, *IRQ_HIGH_LEVEL*.                           |
+|                 | *MED_POWER*, *HIGH_POWER*, *IRQ_LOW_LEVEL*, *IRQ_HIGH_LEVEL*.                                                        |
 +-----------------+----------------------------------------------------------------------------------------------------------------------+
 | machine.I2C     | Option ``MICROPY_PY_MACHINE_I2C`` enabled.                                                                           |
 +-----------------+----------------------------------------------------------------------------------------------------------------------+
@@ -128,7 +128,7 @@ Table :ref:`configuration details <table_mpy_configuration>` below lists specifi
 +-----------------+----------------------------------------------------------------------------------------------------------------------+                                                                                                                                             
 | machine.ADCBlock| All functions implemented.                                                                                           |
 +-----------------+----------------------------------------------------------------------------------------------------------------------+
-| machine.Timer   | mode = Timer.PERIODIC is not supported                                                                               |
+| machine.Timer   | All functions implemented.                                                                                           |
 +-----------------+----------------------------------------------------------------------------------------------------------------------+                                                                                                                                             
 | machine.SPI     | Option ``MICROPY_PY_MACHINE_SPI``, ``MICROPY_PY_MACHINE_SPI_MSB`` , ``MICROPY_PY_MACHINE_SPI_MSB`` enabled.          |
 +-----------------+----------------------------------------------------------------------------------------------------------------------+                                                                                                                                             

--- a/docs/psoc6/quickref.rst
+++ b/docs/psoc6/quickref.rst
@@ -126,6 +126,7 @@ Similar to CPython, the parameters can be passed in any order if keywords are us
 
 Note that the parameters such as ``value`` can only be passed as keyword arguments.  
 
+
 .. note::
 
     The following constructor arguments are NOT supported in this port:
@@ -134,10 +135,24 @@ Note that the parameters such as ``value`` can only be passed as keyword argumen
 
 Methods
 ^^^^^^^
+.. method:: Pin.irq(handler=None, trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING)
+
+Here two arguments should be passed mandatorily. 
+Trigger can be ``Pin.IRQ_FALLING`` or ``Pin.IRQ_RISING`` or ``PIN.IRQ_FALLING||PIN.IRQ_RISING``.
+
+::
+    
+    from machine import Pin
+
+    p0 = Pin('P0_4', value=1, pull=Pin.PULL_UP, mode=Pin.IN)          
+    p1 = Pin('P13_7', value=0, pull=Pin.PULL_DOWN, mode=Pin.OUT)      
+
+    p0.irq(handler=lambda t:p1.high(),trigger=Pin.IRQ_RISING) #configure an IRQ callback function P1.high() when there is a rising edge on pin object p0.
+    
 
 .. method:: Pin.toggle()
 
-   Set pin value to its complement.
+Set pin value to its complement.
 
 
 There's a higher-level abstraction :ref:`machine.Signal <machine.Signal>`
@@ -467,12 +482,10 @@ Use the :mod:`machine.Timer` class::
     from machine import Timer
     import time
     tim = Timer(0) #Default assignment: period=9999, frequency=10000
-    tim.init(period=2000, mode=Timer.ONE_SHOT, callback=lambda t:print(2))
-    time.sleep_ms(100)
+    tim.init(period=2000, mode=Timer.ONE_SHOT, callback=lambda t:print(2)) #mode=Timer.PERIODIC in case of periodic timer
+
 
 Here id=0 should be passed mandatorily.
-
-.. note:: Here mode=Timer.PERIODIC is not currently supported 
 
 ADC (analog to digital conversion)
 ----------------------------------

--- a/ports/psoc6/modules/machine/machine_pin.c
+++ b/ports/psoc6/modules/machine/machine_pin.c
@@ -171,25 +171,24 @@ static cyhal_gpio_drive_mode_t mp_to_cy_get_gpio_drive(uint8_t mode, uint8_t pul
     return cy_drive;
 }
 
-static cyhal_gpio_event_t mp_to_cy_get_interrupt_mode(uint8_t mode){
+static cyhal_gpio_event_t mp_to_cy_get_interrupt_mode(uint8_t mode) {
     cyhal_gpio_event_t event;
-    switch(mode){
+    switch (mode) {
         case GPIO_IRQ_FALLING:
-            event =  CYHAL_GPIO_IRQ_FALL;
+            event = CYHAL_GPIO_IRQ_FALL;
             break;
         case GPIO_IRQ_RISING:
-            event =  CYHAL_GPIO_IRQ_RISE;
+            event = CYHAL_GPIO_IRQ_RISE;
             break;
-        
-        case GPIO_IRQ_RISING|GPIO_IRQ_FALLING:
+
+        case GPIO_IRQ_RISING | GPIO_IRQ_FALLING:
             event = CYHAL_GPIO_IRQ_BOTH;
             break;
     }
     return event;
 }
 
-static void gpio_interrupt_handler(void *handler_arg,  cyhal_gpio_event_t event )
-{
+static void gpio_interrupt_handler(void *handler_arg,  cyhal_gpio_event_t event) {
     machine_pin_io_obj_t *self = handler_arg;
     mp_sched_schedule(self->callback, MP_OBJ_FROM_PTR(self));
 }
@@ -350,14 +349,14 @@ STATIC mp_obj_t machine_pin_low(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_low_obj, machine_pin_low);
 
-// pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING, hard=False)
+// pin.irq(handler=None, trigger=IRQ_FALLING|IRQ_RISING)
 STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_handler, ARG_trigger};
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_handler, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_trigger, MP_ARG_INT, {.u_int = GPIO_IRQ_RISING|GPIO_IRQ_FALLING }},
+        { MP_QSTR_trigger, MP_ARG_INT, {.u_int = GPIO_IRQ_RISING | GPIO_IRQ_FALLING }},
     };
-    
+
     machine_pin_io_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -369,9 +368,9 @@ STATIC mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         cyhal_gpio_event_t event = mp_to_cy_get_interrupt_mode(trigger);
         gpio_callback_data.callback = gpio_interrupt_handler;
         gpio_callback_data.callback_arg = self;
-        cyhal_gpio_register_callback(self->pin_phy->addr,&gpio_callback_data);
-        cyhal_gpio_enable_event(self->pin_phy->addr,event , 3, true);
-   
+        cyhal_gpio_register_callback(self->pin_phy->addr, &gpio_callback_data);
+        cyhal_gpio_enable_event(self->pin_phy->addr, event, 3, true);
+
     }
     return MP_OBJ_FROM_PTR(&gpio_callback_data);
 }
@@ -441,4 +440,4 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &machine_pin_locals_dict
     );
 
-MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[5]);
+MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[113]); // Number of GPIO pins

--- a/ports/psoc6/modules/machine/machine_pin.c
+++ b/ports/psoc6/modules/machine/machine_pin.c
@@ -440,4 +440,4 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &machine_pin_locals_dict
     );
 
-MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[113]); // Number of GPIO pins
+MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[MAX_IO_PINS]);

--- a/ports/psoc6/mpconfigport.h
+++ b/ports/psoc6/mpconfigport.h
@@ -31,7 +31,6 @@
 #include "shared/runtime/interrupt_char.h"
 #include "mpconfigboard.h"
 
-
 // Control over Python builtins
 #define MICROPY_PY_IO_BUFFEREDWRITER            (1)
 #define MICROPY_PY_SELECT                       (1)
@@ -84,6 +83,7 @@
 
 #define MICROPY_SCHEDULER_DEPTH                 (8)
 #define MICROPY_SCHEDULER_STATIC_NODES          (1)
+// #define MICROPY_ENABLE_SCHEDULER                (1)
 
 // Fine control over Python builtins, classes, modules, etc
 #define MICROPY_PY_SYS_PLATFORM                 "psoc6"
@@ -172,17 +172,17 @@ typedef intptr_t mp_off_t;
 #define MICROPY_USE_INTERNAL_PRINTF             (0)
 #define MICROPY_REPL_INFO                       (1)
 
-
 // TODO: helpful to abstract main.c ?
 // #define MICROPY_PORT_INIT_FUNC ??
 // #define MICROPY_PORT_DEINIT_FUNC ??
+
 
 
 #define MICROPY_EVENT_POLL_HOOK_FAST \
     do { \
         extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
-    } while (0)
+    } while (0);
 
 
 #define MICROPY_EVENT_POLL_HOOK \

--- a/ports/psoc6/mphalport.c
+++ b/ports/psoc6/mphalport.c
@@ -9,8 +9,6 @@
 
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
-#include "py/stream.h"
-#include "py/ringbuf.h"
 
 // MTB includes
 #include "cyhal.h"
@@ -22,9 +20,6 @@
 
 extern cyhal_rtc_t psoc6_rtc;
 extern cyhal_timer_t psoc6_timer;
-
-STATIC uint8_t stdin_ringbuf_array[260];
-ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0, 0};
 
 void mp_hal_delay_ms(mp_uint_t ms) {
     #if defined(CY_RTOS_AWARE) || defined(COMPONENT_RTOS_AWARE)

--- a/tests/psoc6/dut/pin.py
+++ b/tests/psoc6/dut/pin.py
@@ -42,5 +42,7 @@ print("pin out value on: ", pin_in.value() == 1)
 pin_out.off()
 print("pin out value off: ", pin_in.value() == 0)
 
-pin_in.irq(handler=lambda t:print("Interrupt triggered"),trigger=Pin.IRQ_RISING|Pin.IRQ_FALLING)
+pin_in.irq(
+    handler=lambda t: print("Interrupt triggered"), trigger=Pin.IRQ_RISING | Pin.IRQ_FALLING
+)
 pin_out.high()

--- a/tests/psoc6/dut/pin.py
+++ b/tests/psoc6/dut/pin.py
@@ -41,3 +41,6 @@ print("pin out value on: ", pin_in.value() == 1)
 
 pin_out.off()
 print("pin out value off: ", pin_in.value() == 0)
+
+pin_in.irq(handler=lambda t:print("Interrupt triggered"),trigger=Pin.IRQ_RISING|Pin.IRQ_FALLING)
+pin_out.high()

--- a/tests/psoc6/dut/pin.py.exp
+++ b/tests/psoc6/dut/pin.py.exp
@@ -6,3 +6,4 @@ pin out value high:  True
 pin out value low:  True
 pin out value on:  True
 pin out value off:  True
+Interrupt triggered

--- a/tests/psoc6/timer.py
+++ b/tests/psoc6/timer.py
@@ -11,4 +11,3 @@ for i in range(200000):
     pass
 
 t.deinit()
-

--- a/tests/psoc6/timer.py
+++ b/tests/psoc6/timer.py
@@ -2,5 +2,13 @@ import time
 from machine import Timer
 
 t = Timer(0)
-t.init(period=2000, mode=Timer.ONE_SHOT, callback=lambda t: print("hello"))
-time.sleep_ms(3000)
+t.init(period=2000, mode=Timer.ONE_SHOT, callback=lambda t: print("Oneshot Timer"))
+time.sleep(30)
+t.deinit()
+t1 = Timer(0)
+t1.init(period=2000, mode=Timer.PERIODIC, callback=lambda t: print("Periodic Timer"))
+for i in range(200000):
+    pass
+
+t.deinit()
+

--- a/tests/psoc6/timer.py.exp
+++ b/tests/psoc6/timer.py.exp
@@ -1,1 +1,9 @@
-hello
+Oneshot Timer
+Periodic Timer
+Periodic Timer
+Periodic Timer
+Periodic Timer
+Periodic Timer
+Periodic Timer
+Periodic Timer
+Periodic Timer


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
1. Implementation of Pin.irq() function
2. Non- Blocking UART  
3. Fix for scheduler
4. Documentation

With these modifications. GPIO interrupt & periodic timer is now working.

**Known issues**: In case of a GPIO interrupt,  after the execution of a print statement inside the callback function( if exists), need to press the Enter key to enter back into REPL.  

since the same case works perfectly in the case of Timer, need to evaluate that in more depth.
