### PR TITLE
Fix mem issue

### DIFF
--- a/.github/workflows/ports_psoc6.yml
+++ b/.github/workflows/ports_psoc6.yml
@@ -70,6 +70,11 @@ jobs:
         devs=($(python tools/psoc6/get-devs.py port -b ${{ matrix.board }} -y tools/psoc6/${{ runner.name }}-devs.yml))
         cd tests
         ./psoc6/run_psoc6_tests.sh --psoc6-multi --dev0 ${devs[0]} --dev1 ${devs[1]}
+    - name: Run psoc6 filesystem test
+      run: | 
+        devs=($(python tools/psoc6/get-devs.py port -b ${{ matrix.board }} -y tools/psoc6/${{ runner.name }}-devs.yml))
+        cd tests
+        ./psoc6/run_psoc6_tests.sh -v --dev0 ${devs[0]} --dev1 ${devs[1]}
     - name: Run psoc6 tests
       run: | 
         devs=($(python tools/psoc6/get-devs.py port -b ${{ matrix.board }} -y tools/psoc6/${{ runner.name }}-devs.yml))

--- a/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
@@ -10,3 +10,14 @@
 #define MICROPY_PY_HASHLIB_MD5                  (1)
 #define MICROPY_PY_HASHLIB_SHA1                 (1)
 #define MICROPY_PY_HASHLIB_SHA256               (1)
+
+// Flash type enablement for board
+#if (MICROPY_PY_EXT_FLASH)
+#define EXT_FLASH_BASE                              (0x00)          /** 0x00 */
+#define EXT_FLASH_SIZE                              (0x4000000)     /** 64MB */
+#define EXT_FLASH_SECTOR_SIZE                       (0x40000)       /** 256KB*/
+#define EXT_FLASH_BLOCK_SIZE_BYTES                  (EXT_FLASH_SECTOR_SIZE) 
+#define EXT_FLASH_PAGE_SIZE                         (0x200)         /** 512 bytes*/
+#endif
+
+

--- a/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
@@ -12,6 +12,7 @@
 #define MICROPY_PY_HASHLIB_SHA256               (1)
 
 // Flash type enablement for board
+#define MICROPY_PY_EXT_FLASH (1)
 #if (MICROPY_PY_EXT_FLASH)
 #define EXT_FLASH_BASE                              (0x00)          /** 0x00 */
 #define EXT_FLASH_SIZE                              (0x4000000)     /** 64MB */

--- a/ports/psoc6/modules/psoc6/psoc6_qspi_flash.c
+++ b/ports/psoc6/modules/psoc6/psoc6_qspi_flash.c
@@ -28,13 +28,11 @@
 #include <stdio.h>
 #include <string.h>
 
-
 // micropython includes
 #include "py/runtime.h"
 #include "extmod/vfs.h"
 #include "modpsoc6.h"
 #include "mplogger.h"
-
 
 // MTB includes
 #include "cyhal.h"
@@ -44,24 +42,14 @@
 #include "cycfg_qspi_memslot.h"
 #include "mphalport.h"
 
-#define FLASH_BASE        (0x00)  // absolute address of xip/qspi flash. Does not depend on ld file values since xip isn't used
-#define FLASH_SIZE        (0x4000000)  // qspi flash is 512 Mb / 64 MB in size
-
-#define FLASH_SECTOR_SIZE (0x40000) // 256 KB sector size uniform (depends on cfg register). See Table 46 of https://www.infineon.com/dgdl/Infineon-S25HS256T_S25HS512T_S25HS01GT_S25HL256T_S25HL512T_S25HL01GT_256-Mb_(32-MB)_512-Mb_(64-MB)_1-Gb_(128-MB)_HS-T_(1.8-V)_HL-T_(3.0-V)_Semper_Flash_with_Quad_SPI-DataSheet-v02_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0ee674b86ee3&da=t
-// However, tests reveal that all sectors are in fact 256 KB deep. The factory settings must have been overwritten at some point.
-// See pg. 22 of above datasheet for address maps.
-#define BLOCK_SIZE_BYTES  (FLASH_SECTOR_SIZE) // TODO: verify, since initial 32 sectors are only 4 KB in size
-// TODO: edit cfg register contents to make all sectors uniform, see pg 25 of https://www.infineon.com/dgdl/Infineon-S25HS256T_S25HS512T_S25HS01GT_S25HL256T_S25HL512T_S25HL01GT_256-Mb_(32-MB)_512-Mb_(64-MB)_1-Gb_(128-MB)_HS-T_(1.8-V)_HL-T_(3.0-V)_Semper_Flash_with_Quad_SPI-DataSheet-v02_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0ee674b86ee3&da=t
-#define FLASH_PAGE_SIZE (0x200) // qspi flash page size is 256 B (Factory default), see pg. 80 of https://www.infineon.com/dgdl/Infineon-S25HS256T_S25HS512T_S25HS01GT_S25HL256T_S25HL512T_S25HL01GT_256-Mb_(32-MB)_512-Mb_(64-MB)_1-Gb_(128-MB)_HS-T_(1.8-V)_HL-T_(3.0-V)_Semper_Flash_with_Quad_SPI-DataSheet-v02_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0ee674b86ee3&da=t
-// but config says it is 512 B
 
 #ifndef MICROPY_HW_FLASH_STORAGE_BYTES
-#define MICROPY_HW_FLASH_STORAGE_BYTES (FLASH_SIZE)
+#define MICROPY_HW_FLASH_STORAGE_BYTES (EXT_FLASH_SIZE)
 #endif
 static_assert(MICROPY_HW_FLASH_STORAGE_BYTES % 4096 == 0, "Flash storage size must be a multiple of 4K");
 
 #ifndef MICROPY_HW_FLASH_STORAGE_BASE
-#define MICROPY_HW_FLASH_STORAGE_BASE (FLASH_BASE)
+#define MICROPY_HW_FLASH_STORAGE_BASE (EXT_FLASH_BASE)
 #endif
 
 // CY Macros
@@ -79,35 +67,41 @@ typedef struct _psoc6_qspi_flash_obj_t {
 
 STATIC psoc6_qspi_flash_obj_t psoc6_qspi_flash_obj = {
     .base = { &psoc6_qspi_flash_type },
-    .flash_base = FLASH_BASE,
-    .flash_size = FLASH_SIZE,
+    .flash_base = EXT_FLASH_BASE,
+    .flash_size = EXT_FLASH_SIZE,
 };
 
 
 // function to erase the entire flash
 void cy_erase_entire_flash(void) {
-    mp_printf(&mp_plat_print, "\nErasing entire flash... might take a while");
+    mp_printf(&mp_plat_print, "\nErasing entire flash... might take a while\n");
     cy_serial_flash_qspi_erase(0, cy_serial_flash_qspi_get_size());
-    mp_printf(&mp_plat_print, "\nDone");
+    mp_printf(&mp_plat_print, "\nDone\n");
 }
 
+// Helper function to get external flash configurations
+void get_ext_flash_info(void) {
+    mplogger_print("\nRetrieving external flash info...\n");
+    mplogger_print("\nTotal flash size (MB): %d\n", cy_serial_flash_qspi_get_size() / (1024 * 1024));
+    mplogger_print("\nSize of erase sector (bytes): %d\n", cy_serial_flash_qspi_get_erase_size(0x00) / (1024));
+    mplogger_print("\nPage size (bytes): %d\n", cy_serial_flash_qspi_get_prog_size(0x00));
+}
 
 STATIC mp_obj_t psoc6_qspi_flash_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    mplogger_print("qspi flash constructor invoked\n");
+    mplogger_print("\nQSPI flash constructor invoked\n");
+    get_ext_flash_info();
 
-    // variable initialized to capture status
     cy_rslt_t result = CY_RSLT_SUCCESS;
-    // init only if not init before
+
     if (!qspi_flash_init) {
-        /* Initialize the QSPI block */
         result = cy_serial_flash_qspi_init(smifMemConfigs[MEM_SLOT_NUM], CYBSP_QSPI_D0, CYBSP_QSPI_D1,
             CYBSP_QSPI_D2, CYBSP_QSPI_D3, NC, NC, NC, NC, CYBSP_QSPI_SCK,
             CYBSP_QSPI_SS, QSPI_BUS_FREQUENCY_HZ);
         qspi_flash_init = 1;
     }
     if (CY_RSLT_SUCCESS != result) {
-        mplogger_print("Error code: %u\n", CY_RSLT_GET_CODE(result)); // see file cy_result.h to decode result values
-        mp_raise_msg(&mp_type_Exception, MP_ERROR_TEXT("QSPI Flash INIT failed !\n"));
+        mplogger_print("psoc6_qspi_flash_make_new() failed while initializing flash with error code : %u\n", CY_RSLT_GET_CODE(result));
+        mp_raise_msg(&mp_type_Exception, MP_ERROR_TEXT("psoc6_qspi_flash_make_new() - QSPI flash init failed !\n"));
     }
 
     // Parse arguments
@@ -132,7 +126,7 @@ STATIC mp_obj_t psoc6_qspi_flash_make_new(const mp_obj_type_t *type, size_t n_ar
 
     if (start == -1) {
         start = 0;
-    } else if (!(0 <= start && start < MICROPY_HW_FLASH_STORAGE_BYTES && start % BLOCK_SIZE_BYTES == 0)) {
+    } else if (!(0 <= start && start < MICROPY_HW_FLASH_STORAGE_BYTES && start % EXT_FLASH_BLOCK_SIZE_BYTES == 0)) {
         mp_raise_ValueError(MP_ERROR_TEXT("Invalid 'start' value specified for psoc6_flash_make_new !\n"));
     }
 
@@ -140,7 +134,7 @@ STATIC mp_obj_t psoc6_qspi_flash_make_new(const mp_obj_type_t *type, size_t n_ar
 
     if (len == -1) {
         len = MICROPY_HW_FLASH_STORAGE_BYTES - start;
-    } else if (!(0 < len && start + len <= MICROPY_HW_FLASH_STORAGE_BYTES && len % BLOCK_SIZE_BYTES == 0)) {
+    } else if (!(0 < len && start + len <= MICROPY_HW_FLASH_STORAGE_BYTES && len % EXT_FLASH_BLOCK_SIZE_BYTES == 0)) {
         mp_raise_ValueError(MP_ERROR_TEXT("Invalid 'len' value specified for psoc6_flash_make_new !\n"));
     }
 
@@ -151,9 +145,10 @@ STATIC mp_obj_t psoc6_qspi_flash_make_new(const mp_obj_type_t *type, size_t n_ar
 }
 
 STATIC mp_obj_t psoc6_qspi_flash_readblocks(size_t n_args, const mp_obj_t *args) {
-    mplogger_print("qspi flash readblocks called\n");
+    mplogger_print("\nQSPI flash readblocks called\n");
+
     psoc6_qspi_flash_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-    uint32_t offset = mp_obj_get_int(args[1]) * BLOCK_SIZE_BYTES;
+    uint32_t offset = mp_obj_get_int(args[1]) * EXT_FLASH_BLOCK_SIZE_BYTES;
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_WRITE);
 
@@ -166,8 +161,8 @@ STATIC mp_obj_t psoc6_qspi_flash_readblocks(size_t n_args, const mp_obj_t *args)
     cy_rslt_t result = cy_serial_flash_qspi_read(self->flash_base + offset, bufinfo.len, bufinfo.buf);
 
     if (CY_RSLT_SUCCESS != result) {
-        mplogger_print("Error code: %u\n", CY_RSLT_GET_CODE(result));
-        mp_raise_ValueError(MP_ERROR_TEXT("QSPI Flash Read failed !"));
+        mplogger_print("psoc6_qspi_flash_readblocks() failed while reading the flash with error code: %u\n", CY_RSLT_GET_CODE(result));
+        mp_raise_ValueError(MP_ERROR_TEXT("psoc6_qspi_flash_readblocks() - QSPI Flash Read failed !"));
     }
     MICROPY_END_ATOMIC_SECTION(atomic_state); // end atomic section
     ;
@@ -176,9 +171,9 @@ STATIC mp_obj_t psoc6_qspi_flash_readblocks(size_t n_args, const mp_obj_t *args)
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(psoc6_qspi_flash_readblocks_obj, 3, 4, psoc6_qspi_flash_readblocks);
 
 STATIC mp_obj_t psoc6_qspi_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
-    mplogger_print("qspi flash writeblocks called\n");
+    mplogger_print("\nQSPI flash writeblocks called\n");
     psoc6_qspi_flash_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-    uint32_t offset = mp_obj_get_int(args[1]) * BLOCK_SIZE_BYTES;
+    uint32_t offset = mp_obj_get_int(args[1]) * EXT_FLASH_BLOCK_SIZE_BYTES;
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
 
@@ -189,16 +184,16 @@ STATIC mp_obj_t psoc6_qspi_flash_writeblocks(size_t n_args, const mp_obj_t *args
         // TODO: that function must be made non-static first.
         // TODO: or, reimplement MICROPY_BEGIN_ATOMIC_SECTION() as a simple macro
         mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION(); // begin atomic section
-        uint32_t numSectors = bufinfo.len / FLASH_SECTOR_SIZE;
+        uint32_t numSectors = bufinfo.len / EXT_FLASH_SECTOR_SIZE;
 
         for (uint32_t i = 0; i <= numSectors; ++i) {
-            mplogger_print("Address in hex:%04X\n", self->flash_base + offset + i * FLASH_SECTOR_SIZE);
-            cy_rslt_t result = cy_serial_flash_qspi_erase(self->flash_base + offset + i * FLASH_SECTOR_SIZE, cy_serial_flash_qspi_get_erase_size(self->flash_base + offset + i * FLASH_SECTOR_SIZE));
+            mplogger_print("Address in hex:%04X\n", self->flash_base + offset + i * EXT_FLASH_SECTOR_SIZE);
+            cy_rslt_t result = cy_serial_flash_qspi_erase(self->flash_base + offset + i * EXT_FLASH_SECTOR_SIZE, cy_serial_flash_qspi_get_erase_size(self->flash_base + offset + i * EXT_FLASH_SECTOR_SIZE));
             // the cy_serial_flash_qspi_get_erase_size() function call is necessary to keep the erase at sector boundary, else it throws errors.
 
             if (CY_RSLT_SUCCESS != result) {
-                mplogger_print("Error code: %u\n", CY_RSLT_GET_CODE(result));
-                mp_raise_ValueError(MP_ERROR_TEXT("QSPI Flash Erase failed !"));
+                mplogger_print("\npsoc6_qspi_flash_writeblocks() failed while erasing the flash with error code: %u\n", CY_RSLT_GET_CODE(result));
+                mp_raise_ValueError(MP_ERROR_TEXT("psoc6_qspi_flash_writeblocks() - QSPI flash Erase failed !"));
             }
         }
 
@@ -207,27 +202,23 @@ STATIC mp_obj_t psoc6_qspi_flash_writeblocks(size_t n_args, const mp_obj_t *args
         offset += mp_obj_get_int(args[3]);
     }
 
-
     // Flash erase/program must run in an atomic section.
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
-    uint32_t numPages = bufinfo.len / FLASH_PAGE_SIZE;
+    // uint32_t numPages = bufinfo.len / EXT_FLASH_PAGE_SIZE;
 
-    for (uint32_t i = 0; i <= numPages; ++i) {
-        mplogger_print("Address in hex:%04X\n", self->flash_base + offset + i * FLASH_PAGE_SIZE);
-        cy_rslt_t result = cy_serial_flash_qspi_write(self->flash_base + offset + i * FLASH_PAGE_SIZE, FLASH_PAGE_SIZE, bufinfo.buf + i * FLASH_PAGE_SIZE);  // TODO: verify this
-
-        if (CY_RSLT_SUCCESS != result) {
-            mplogger_print("Error code: %u\n", CY_RSLT_GET_CODE(result));
-            mp_raise_ValueError(MP_ERROR_TEXT("QSPI Flash Write failed !")); // TODO: replace with proper exception message. also few instances above and below.
-        }
+    cy_rslt_t result = cy_serial_flash_qspi_write(self->flash_base + offset, bufinfo.len, bufinfo.buf);
+    if (CY_RSLT_SUCCESS != result) {
+        mplogger_print("psoc6_qspi_flash_writeblocks() failed while writing with error code: %u\n", CY_RSLT_GET_CODE(result));
+        mp_raise_ValueError(MP_ERROR_TEXT("psoc6_qspi_flash_writeblocks() - QSPI Flash Write failed!"));
     }
+
     MICROPY_END_ATOMIC_SECTION(atomic_state);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(psoc6_qspi_flash_writeblocks_obj, 3, 4, psoc6_qspi_flash_writeblocks);
 
 STATIC mp_obj_t psoc6_qspi_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj_t arg_in) {
-    mplogger_print("qspi flash ioctrl called\n");
+    mplogger_print("QSPI flash ioctrl called\n");
     psoc6_qspi_flash_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t cmd = mp_obj_get_int(cmd_in);
     mplogger_print("option:%u\n", cmd);
@@ -250,17 +241,18 @@ STATIC mp_obj_t psoc6_qspi_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj
         case MP_BLOCKDEV_IOCTL_SYNC:
             return MP_OBJ_NEW_SMALL_INT(0);
         case MP_BLOCKDEV_IOCTL_BLOCK_COUNT:
-            return MP_OBJ_NEW_SMALL_INT(self->flash_size / BLOCK_SIZE_BYTES);
+            return MP_OBJ_NEW_SMALL_INT(self->flash_size / EXT_FLASH_BLOCK_SIZE_BYTES);
         case MP_BLOCKDEV_IOCTL_BLOCK_SIZE:
-            return MP_OBJ_NEW_SMALL_INT(BLOCK_SIZE_BYTES);
+            return MP_OBJ_NEW_SMALL_INT(EXT_FLASH_BLOCK_SIZE_BYTES);
         case MP_BLOCKDEV_IOCTL_BLOCK_ERASE: {
-            uint32_t offset = mp_obj_get_int(arg_in) * BLOCK_SIZE_BYTES;
+            uint32_t offset = mp_obj_get_int(arg_in) * EXT_FLASH_BLOCK_SIZE_BYTES;
             // Flash erase/program must run in an atomic section.
             mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION(); // begin atomic section
             cy_rslt_t result = cy_serial_flash_qspi_erase(self->flash_base + offset, cy_serial_flash_qspi_get_erase_size(self->flash_base + offset));
 
             if (CY_RSLT_SUCCESS != result) {
-                mp_raise_ValueError(MP_ERROR_TEXT("QSPI Flash Erase failed !"));
+                mplogger_print("psoc6_qspi_flash_ioctl() failed while erasing block with error code: %u\n", CY_RSLT_GET_CODE(result));
+                mp_raise_ValueError(MP_ERROR_TEXT("psoc6_qspi_flash_ioctl() - QSPI Flash erase failed !"));
             }
             MICROPY_END_ATOMIC_SECTION(atomic_state); // end atomic section
             return MP_OBJ_NEW_SMALL_INT(0);

--- a/ports/psoc6/modules/psoc6/psoc6_qspi_flash.c
+++ b/ports/psoc6/modules/psoc6/psoc6_qspi_flash.c
@@ -239,14 +239,12 @@ STATIC mp_obj_t psoc6_qspi_flash_ioctl(mp_obj_t self_in, mp_obj_t cmd_in, mp_obj
             return MP_OBJ_NEW_SMALL_INT(EXT_FLASH_BLOCK_SIZE_BYTES);
         case MP_BLOCKDEV_IOCTL_BLOCK_ERASE: {
             uint32_t offset = mp_obj_get_int(arg_in) * EXT_FLASH_BLOCK_SIZE_BYTES;
-            mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
             cy_rslt_t result = cy_serial_flash_qspi_erase(self->flash_base + offset, cy_serial_flash_qspi_get_erase_size(self->flash_base + offset));
 
             if (CY_RSLT_SUCCESS != result) {
                 mplogger_print("psoc6_qspi_flash_ioctl() failed while erasing block with error code: %u\n", CY_RSLT_GET_CODE(result));
                 mp_raise_ValueError(MP_ERROR_TEXT("psoc6_qspi_flash_ioctl() - QSPI Flash erase failed !"));
             }
-            MICROPY_END_ATOMIC_SECTION(atomic_state);
             return MP_OBJ_NEW_SMALL_INT(0);
         }
         default:

--- a/ports/psoc6/mphalport.c
+++ b/ports/psoc6/mphalport.c
@@ -148,17 +148,3 @@ void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj) {
     return pin_addr_by_name(obj);
 }
-
-
-// TODO: move to another file or define as macro in mpconfigport.h
-mp_uint_t begin_atomic_section() {
-    // __disable_irq();
-    // return 0;
-    return cyhal_system_critical_section_enter();
-}
-
-
-void end_atomic_section(mp_uint_t state) {
-    // __enable_irq();
-    cyhal_system_critical_section_exit(state);
-}

--- a/ports/psoc6/mphalport.h
+++ b/ports/psoc6/mphalport.h
@@ -14,8 +14,11 @@
 
 // port-specific includes
 
-#define MICROPY_BEGIN_ATOMIC_SECTION()      (0)
-#define MICROPY_END_ATOMIC_SECTION(state)   {(void)state;}
+#define MICROPY_BEGIN_ATOMIC_SECTION()     cyhal_system_critical_section_enter()
+#define MICROPY_END_ATOMIC_SECTION(state)  cyhal_system_critical_section_exit(state)
+
+// #define MICROPY_BEGIN_ATOMIC_SECTION()      (0)
+// #define MICROPY_END_ATOMIC_SECTION(state)   {(void)state;}
 
 #define MP_HAL_PIN_FMT   "%u"
 #define mp_hal_pin_obj_t uint
@@ -53,10 +56,6 @@ void mp_hal_pin_input(mp_hal_pin_obj_t pin);
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags);
 
 int mp_hal_stdin_rx_chr(void);
-
-mp_uint_t begin_atomic_section();
-void end_atomic_section(mp_uint_t state);
-
 
 static inline void mp_hal_pin_config(mp_hal_pin_obj_t pin, uint32_t mode, uint32_t pull, uint32_t alt) {
     printf("mp_hal_pin_config %d   mode : %ld   pull : %ld   alt : %ld\n", pin, mode, pull, alt);

--- a/tests/psoc6/run_psoc6_tests.sh
+++ b/tests/psoc6/run_psoc6_tests.sh
@@ -17,9 +17,10 @@ usage() {
   echo "  -i            run implemented tests only and exclude known failing tests"
   echo "  -n            run not yet implemented tests only"
   echo "  -w            run wifi tests => needs secrets.py key file>"
+  echo "  -v            run virtual filesystem related tests"
   echo "  --dev0        device to be used"
   echo "  --dev1        second device to be used (for multi test)"
-  echo "  --psco6       run only psoc6 port related tests"
+  echo "  --psoc6       run only psoc6 port related tests"
   echo "  --psoc6-multi run only psoc6 port multi tests (requires 2 instances)"
   exit 1;
 }
@@ -36,7 +37,7 @@ for arg in "$@"; do
   esac
 done
 
-while getopts "acd:e:fhimnpw" o; do
+while getopts "acd:e:fhimnpwv" o; do
   case "${o}" in
     a)
        all=1
@@ -70,6 +71,9 @@ while getopts "acd:e:fhimnpw" o; do
        ;;
     w)
        wifi=1
+       ;;
+    v)
+       fs=1
        ;;
     *)
        usage
@@ -113,6 +117,10 @@ fi
 
 if [ -z "${wifi}" ]; then
   wifi=0
+fi
+
+if [ -z "${fs}" ]; then
+  fs=0
 fi
 
 if [ -z "${psoc6OnlyMulti}" ]; then
@@ -229,6 +237,24 @@ if [ ${wifi} -eq 1 ]; then
 
 fi
 
+if [ ${fs} -eq 1 ]; then
+
+  echo "  running filesystem tests ..."
+  echo
+
+  ./run-tests.py --target psoc6 --device ${device0} \
+         \
+          extmod/vfs_basic.py \
+          extmod/vfs_lfs_superblock.py \
+          extmod/vfs_userfs.py \
+    | tee -a ${resultsFile}
+
+  echo
+  echo "  done."
+  echo
+
+fi
+
 
 if [ ${implemented} -eq 1 ]; then
 
@@ -268,7 +294,7 @@ if [ ${implemented} -eq 1 ]; then
         \
         -e extmod/re_stack_overflow.py \
         -e extmod/socket_udp_nonblock.py \
-        -e extmod/vfs_lfs_mtime.py \
+
         \
         -e feature_check/async_check.py \
         -e feature_check/bytearray.py \


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

**Description**:
Provides fix for large file transfer issue as raised by the community user.

**Issues**: 

- The write blocks enabled for the port were not correctly configured to handle larger data.
- Atomic sections were not enabled and hence not allowing the FS operations to run without any other system interrupts.

**Resolution**:
- Enabled atomic sections
- Refactored psoc6 qspi flash API.
- Moved flash configurations from src files to board config.
- Enabled micropython offered tests and the corresponding changes to run them in our CI/CD pipeline.

**Related Issue**:
[DESMAKERS-3481](https://jirard.intra.infineon.com/browse/DESMAKERS-3481)
[DESMAKERS-3495](https://jirard.intra.infineon.com/browse/DESMAKERS-3495)
