### PR TITLE
add workflow to automatically close stale issues

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,8 @@
+name: 'Close stale issues/PRs'
+on:
+  schedule:
+    - cron: "50 14 */2 * *"
+
+jobs:
+  call-workflow:
+    uses: Infineon/workflows/.github/workflows/epe_stale_issues.yml@master


### PR DESCRIPTION
Adding a workflow reference to the reusable workflow at:
https://github.com/Infineon/workflows/blob/master/.github/workflows/epe_stale_issues.yml

To automatically handle and close stale issues.