### PR TITLE
ports/psoc6: Https fix.

### DIFF
--- a/ports/psoc6/boards/CY8CKIT-062S2-AI/manifest.py
+++ b/ports/psoc6/boards/CY8CKIT-062S2-AI/manifest.py
@@ -1,3 +1,3 @@
 freeze("$(PORT_DIR)/freeze")
 include("$(MPY_DIR)/extmod/asyncio")
-require("mip")
+require("bundle-networking")

--- a/ports/psoc6/boards/CY8CPROTO-062-4343W/manifest.py
+++ b/ports/psoc6/boards/CY8CPROTO-062-4343W/manifest.py
@@ -1,3 +1,3 @@
 freeze("$(PORT_DIR)/freeze")
 include("$(MPY_DIR)/extmod/asyncio")
-require("mip")
+require("bundle-networking")

--- a/ports/psoc6/boards/CY8CPROTO-063-BLE/manifest.py
+++ b/ports/psoc6/boards/CY8CPROTO-063-BLE/manifest.py
@@ -1,3 +1,3 @@
 freeze("$(PORT_DIR)/freeze")
 include("$(MPY_DIR)/extmod/asyncio")
-require("mip")
+require("bundle-networking")

--- a/ports/psoc6/mbedtls/mbedtls_config.h
+++ b/ports/psoc6/mbedtls/mbedtls_config.h
@@ -29,6 +29,4 @@
 #include "mbedtls_config_common.h"
 // #endif
 
-#undef MBEDTLS_ENTROPY_HARDWARE_ALT
-
 #endif /* PSOC6_MPY_MBEDTLS_USER_CONFIG_HEADER */


### PR DESCRIPTION
Fixed access to HTTPS links and thereby mip is working. 

connect the board to the network and try installing using mip

import mip
mip.install('neopixel')
mip. install("https://raw.githubusercontent.com/jaenrig-ifx/micropython-lib/mpy-lib/pasco2-sensor-module/micropython/drivers/sensor/pasco2/pasco2.py")

or anything else. I hope this works on your end also!
