### PR TITLE
tests/ports/psoc6/fs: Refactor fs large ffile script.

### DIFF
--- a/tests/ports/psoc6/run_psoc6_tests.sh
+++ b/tests/ports/psoc6/run_psoc6_tests.sh
@@ -154,16 +154,14 @@ mpremote_vfs_large_file_tests() {
 
   # On device file saving tests for medium and large size takes considerable 
   # amount of time. Hence only when needed, this should be triggered.
-  enable_adv_tests=0
+  enable_adv_tests="basic"
   if [ ${afs} -eq 1 ]; then
-    enable_adv_tests=1
+     enable_adv_tests="adv"
   fi
 
   python3 ${tests_psoc6_dir}/test_scripts/fs.py ${dev_test} ${enable_adv_tests} ${storage_device}
-  if [ $? -ne 0 ]; then
-    echo "FS test failed"
-    exit 1
-  fi
+  
+  update_test_result $?
 }
 
 vfs_flash_tests() {

--- a/tests/ports/psoc6/test_scripts/fs.py
+++ b/tests/ports/psoc6/test_scripts/fs.py
@@ -40,8 +40,9 @@ def get_test_input_files(test_type):
     cp_input_files = [
         "test_fs_small_file.txt",
         "test_fs_medium_file.txt",
-    ]  # , "test_fs_large_file.txt"]
-    input_files_sizes = ["10240", "511876"]  # , '1047584']
+        "test_fs_large_file.txt",
+    ]
+    input_files_sizes = ["10240", "511876", "1047584"]
 
     if test_type == "basic":
         return [cp_input_files[0]], [input_files_sizes[0]]

--- a/tests/ports/psoc6/test_scripts/fs.py
+++ b/tests/ports/psoc6/test_scripts/fs.py
@@ -6,106 +6,163 @@ device = sys.argv[1]
 test_type = sys.argv[2]
 mem_type = sys.argv[3]
 
+# tests inputs and script paths
 test_input_dir = "./ports/psoc6/test_inputs"
 test_script_dir = "./ports/psoc6/test_scripts"
 
-# local and remote(MPY device) paths
-local_small_file_path = f"{test_input_dir}/test_fs_small_file.txt"
-local_medium_file_path = f"{test_input_dir}/test_fs_medium_file.txt"
-local_large_file_path = f"{test_input_dir}/test_fs_large_file.txt"
-
-if mem_type == "sd":
-    remote_directory_path = "/sd/"
-    basic_test_op_fp = f"{test_script_dir}/fs_basic_sd.py.out"
-    adv_test_op_fp = f"{test_script_dir}/fs_adv_sd.py.out"
-    exp_basic_op_fp = f"{test_script_dir}/fs_basic_sd.py.exp"
-    exp_adv_op_fp = f"{test_script_dir}/fs_adv_sd.py.exp"
-
-    mount_sd_script = f"{test_script_dir}/fs_mount_sd.py"
-    mpr_run_script = f"run {mount_sd_script}"
-else:
-    remote_directory_path = "/"
-    # out and exp file paths
-    basic_test_op_fp = f"{test_script_dir}/fs_basic.py.out"
-    adv_test_op_fp = f"{test_script_dir}/fs_adv.py.out"
-    exp_basic_op_fp = f"{test_script_dir}/fs_basic.py.exp"
-    exp_adv_op_fp = f"{test_script_dir}/fs_adv.py.exp"
-
-    mpr_run_script = ""
-
 # List of mpremote commands
 mpr_connect = f"../tools/mpremote/mpremote.py connect {device}"
+mpr_run_script = ""
 
-mpr_small_file_cp = (
-    f"{mpr_connect} {mpr_run_script} cp {local_small_file_path} :{remote_directory_path}"
-)
-mpr_medium_file_cp = (
-    f"{mpr_connect} {mpr_run_script} cp {local_medium_file_path} :{remote_directory_path}"
-)
-mpr_large_file_cp = (
-    f"{mpr_connect} {mpr_run_script} cp {local_large_file_path} :{remote_directory_path}"
-)
-mpr_ls = f"{mpr_connect} {mpr_run_script} fs ls /"
-mpr_rm = f"{mpr_connect} {mpr_run_script} fs rm "
+# Remote directory path
+remote_directory_path = ""
 
 
-def exec(cmd, op_file_path="null"):
-    if cmd == mpr_rm:
-        # Check if file is present already
-        output = subprocess.run(f"{mpr_ls} | grep {op_file_path}", shell=True, capture_output=True)
-        # If the file is present, remove it
-        if output.returncode == 0:
-            subprocess.run(f"{cmd} {op_file_path}", shell=True, capture_output=False)
+def set_mpr_run_script(mem_type):
+    # Required to mount the sd card if the test is for the sd card
+    global mpr_run_script
+    if mem_type == "sd":
+        mpr_run_script = f"run {test_script_dir}/fs_mount_sd.py"
+
+
+def set_remote_dir_path(mem_type):
+    # Set test directory path based on the memory type
+    global remote_directory_path
+    if mem_type == "sd":
+        remote_directory_path = "/sd/"
     else:
-        if os.path.exists(op_file_path):
-            os.remove(op_file_path)
-        with open(op_file_path, "a") as file:
-            subprocess.check_call(cmd, shell=True, stdout=file)
-            file.close()
+        remote_directory_path = "/"
 
 
-def validate_test(op, exp_op):
-    with open(op, "r") as output_file:
-        output = [line.strip() for line in output_file]
-        output_file.close()
+def get_test_input_files(test_type):
+    # The "basic" test uses only the small file
+    # While the "adv" (advanced) tests uses all the files
+    cp_input_files = [
+        "test_fs_small_file.txt",
+        "test_fs_medium_file.txt",
+    ]  # , "test_fs_large_file.txt"]
+    input_files_sizes = ["10240", "511876"]  # , '1047584']
 
-    with open(exp_op, "r") as exp_output_file:
-        exp_output = [line.strip() for line in exp_output_file]
-        exp_output_file.close()
+    if test_type == "basic":
+        return [cp_input_files[0]], [input_files_sizes[0]]
+    elif test_type == "adv":
+        return cp_input_files, input_files_sizes
 
-    if output != exp_output:
-        print("Operation failed!")
-        sys.exit(1)
+
+def get_test_name(test_type, mem_type):
+    # Specify variant tests in test printed name
+    if mem_type == "sd":
+        mem_type_suffix = "_sd"
+    elif mem_type == "flash":
+        mem_type_suffix = ""
+
+    return f"fs_{test_type}{mem_type_suffix}.py"
+
+
+def ls_files(files):
+    # It will return an array with the file size found in the remote directory
+    # If -1, the file was not found
+    mpr_ls = f"{mpr_connect} {mpr_run_script} fs ls {remote_directory_path}"
+    output = subprocess.run(f"{mpr_ls}", shell=True, capture_output=True)
+
+    files_result = []
+    lines = output.stdout.decode().split("\r\n")
+
+    for file in files:
+        file_size = -1
+        for line in lines:
+            line = line.split()
+            if file in line:
+                file_size = line[0]
+
+        files_result.append(file_size)
+
+    return files_result
+
+
+def rm_files(files):
+    # It will remove the files in the remote directory
+    # The command will be concatenated with the files to remove. Example:
+    # ../tools/mpremote/mpremote.py connect /dev/ttyACM0 fs rm /test_fs_medium_file.txt + fs rm /test_fs_medium_file.txt
+    mpr_rm = f"{mpr_connect} {mpr_run_script} fs rm "
+
+    rm_sub_cmd = ""
+    last_file = files[-1]
+    for file in files:
+        append_cmd_operand = ""
+        if last_file != file:
+            append_cmd_operand = " + "
+
+        rm_sub_cmd += f"fs rm {remote_directory_path}{file}{append_cmd_operand}"
+
+    subprocess.run(f"{mpr_connect} {mpr_run_script} {rm_sub_cmd}", shell=True, capture_output=True)
+
+
+def rm_files_if_exist(files):
+    matches = ls_files(files)
+
+    # Take only the files that which sizes are not -1 (the existing files in the remote directory)
+    existing_files = []
+    for i in range(len(matches)):
+        if matches[i] != -1:
+            existing_files.append(files[i])
+
+    # Remove any found input files in the remote directory
+    if existing_files != []:
+        print(f"Removing existing files...")
+        rm_files(existing_files)
+        if ls_files(files) == [-1 for _ in range(len(files))]:
+            print(f"Existing files removed.")
+
+
+def copy_files(input_cp_files):
+    ### This will create a command with concatenation of cp commands for each file in the list:
+    # ../tools/mpremote/mpremote.py connect /dev/ttyACM0 fs cp ./ports/psoc6/test_inputs/test_fs_medium_file.txt :/ + fs cp ./ports/psoc6/test_inputs/test_fs_medium_file.txt :/
+    cp_sub_cmd = ""
+    last_file = input_cp_files[-1]
+    for file in input_cp_files:
+        append_cmd_operand = ""
+        if last_file != file:
+            append_cmd_operand = " + "
+        cp_sub_cmd += f"cp {test_input_dir}/{file} :{remote_directory_path}{append_cmd_operand}"
+
+    cp_cmd = f"{mpr_connect} {mpr_run_script} {cp_sub_cmd}"
+
+    subprocess.run(cp_cmd, shell=True, capture_output=True)
+
+
+def validate_test(files, file_sizes):
+    # This function will validate the test by comparing the file sizes found with ls
+    # in the remote directory with the expected file sizes
+    found_sizes = ls_files(files)
+
+    if found_sizes != file_sizes:
+        msg = "fail"
+        exit_code = 1
     else:
-        print("Operation successful!")
+        msg = "pass"
+        exit_code = 0
+
+    # Print the test result
+    print(f"\n{msg}  {get_test_name(test_type, mem_type)}")
+
+    # Exit with the exit code
+    sys.exit(exit_code)
 
 
-def fs_basic_test():
-    print("Running basic test")
-    print("Saving small file - 10KB")
-    exec(mpr_rm, "test_fs_small_file.txt")
-    exec(mpr_small_file_cp, basic_test_op_fp)
-    validate_test(basic_test_op_fp, exp_basic_op_fp)
-    os.remove(basic_test_op_fp)
+def cp_files_test(input_files, input_files_size):
+    rm_files_if_exist(input_files)
+    copy_files(input_files)
+    validate_test(input_files, input_files_size)
 
 
-def fs_adv_test():
-    print("Running advance test")
-    print("Saving small files - 10KB")
-    exec(mpr_rm, "test_fs_small_file.txt")
-    exec(mpr_small_file_cp, adv_test_op_fp)
-    print("Saving medium files - 500KB")
-    exec(mpr_rm, "test_fs_medium_file.txt")
-    exec(mpr_medium_file_cp, adv_test_op_fp)
-    print("Saving large files - 1MB")
-    exec(mpr_rm, "test_fs_large_file.txt")
-    exec(mpr_large_file_cp, adv_test_op_fp)
-    validate_test(adv_test_op_fp, exp_adv_op_fp)
-    os.remove(adv_test_op_fp)
+def large_file_tests(device, test_type, mem_type):
+    set_mpr_run_script(mem_type)
+    set_remote_dir_path(mem_type)
+
+    input_files, input_files_size = get_test_input_files(test_type)
+
+    cp_files_test(input_files, input_files_size)
 
 
-if test_type == "0":
-    fs_basic_test()
-
-if test_type == "1":
-    fs_adv_test()
+large_file_tests(device, test_type, mem_type)

--- a/tests/ports/psoc6/test_scripts/fs_adv.py.exp
+++ b/tests/ports/psoc6/test_scripts/fs_adv.py.exp
@@ -1,3 +1,0 @@
-cp ./ports/psoc6/test_inputs/test_fs_small_file.txt :/
-cp ./ports/psoc6/test_inputs/test_fs_medium_file.txt :/
-cp ./ports/psoc6/test_inputs/test_fs_large_file.txt :/

--- a/tests/ports/psoc6/test_scripts/fs_adv_sd.py.exp
+++ b/tests/ports/psoc6/test_scripts/fs_adv_sd.py.exp
@@ -1,5 +1,0 @@
-
-SD card mounted at /sd
-cp ./ports/psoc6/test_inputs/test_fs_small_file.txt :/sd/
-cp ./ports/psoc6/test_inputs/test_fs_medium_file.txt :/sd/
-cp ./ports/psoc6/test_inputs/test_fs_large_file.txt :/sd/

--- a/tests/ports/psoc6/test_scripts/fs_basic.py.exp
+++ b/tests/ports/psoc6/test_scripts/fs_basic.py.exp
@@ -1,1 +1,0 @@
-cp ./ports/psoc6/test_inputs/test_fs_small_file.txt :/

--- a/tests/ports/psoc6/test_scripts/fs_basic_sd.py.exp
+++ b/tests/ports/psoc6/test_scripts/fs_basic_sd.py.exp
@@ -1,2 +1,0 @@
-SD card mounted at /sd
-cp ./ports/psoc6/test_inputs/test_fs_small_file.txt :/sd/


### PR DESCRIPTION
New fs tests does not check on output of cp commands, but it does the following:

- Set the list of files to copy to the device memory based on "basic" or "adv" (advance) tests
- Check if those files already exist on the device by listing the specific path: (fs ls command)
- Remove the files if they already exists (rm command)
- Copy the files (cp command)
- Check if the files have been properly copied (fs command)


