### PR TITLE
Fix machine obj instances

### DIFF
--- a/ports/psoc6/boards/CY8CKIT-062S2-AI/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CKIT-062S2-AI/mpconfigboard.h
@@ -27,9 +27,9 @@
 #endif
 
 // Board specific configurations
-#define MAX_UART             2 
-#define MAX_TIMER (32)
-#define MAX_SPI              10 
-#define MAX_I2C              10 
-#define MAX_PWM_OBJS 10 
-#define MICROPY_HW_MAX_I2S 2 
+#define MAX_UART             6 
+#define MAX_TIMER            32
+#define MAX_SPI              6
+#define MAX_I2C              5 
+#define MAX_PWM_OBJS         32 
+#define MICROPY_HW_MAX_I2S   1 

--- a/ports/psoc6/boards/CY8CKIT-062S2-AI/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CKIT-062S2-AI/mpconfigboard.h
@@ -27,7 +27,9 @@
 #endif
 
 // Board specific configurations
-#define MAX_UART             2 // TODO: Change as per bsp?
+#define MAX_UART             2 
 #define MAX_TIMER (32)
-
-
+#define MAX_SPI              10 
+#define MAX_I2C              10 
+#define MAX_PWM_OBJS 10 
+#define MICROPY_HW_MAX_I2S 2 

--- a/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
@@ -29,9 +29,9 @@
 #endif
 
 // Board specific configurations
-#define MAX_UART             2 
-#define MAX_TIMER (32)
-#define MAX_SPI              10 
-#define MAX_I2C              10 
-#define MAX_PWM_OBJS 10 
-#define MICROPY_HW_MAX_I2S 2 
+#define MAX_UART             10 
+#define MAX_TIMER            32
+#define MAX_SPI              7 
+#define MAX_I2C              9 
+#define MAX_PWM_OBJS         32 
+#define MICROPY_HW_MAX_I2S   2 

--- a/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CPROTO-062-4343W/mpconfigboard.h
@@ -28,7 +28,10 @@
 #define EXT_FLASH_PAGE_SIZE                         (0x200)         /** 512 bytes*/
 #endif
 
-#define MAX_UART             10 // TODO: Change as per bsp?
-
 // Board specific configurations
+#define MAX_UART             2 
 #define MAX_TIMER (32)
+#define MAX_SPI              10 
+#define MAX_I2C              10 
+#define MAX_PWM_OBJS 10 
+#define MICROPY_HW_MAX_I2S 2 

--- a/ports/psoc6/boards/CY8CPROTO-063-BLE/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CPROTO-063-BLE/mpconfigboard.h
@@ -9,5 +9,9 @@
 #define MICROPY_PY_MACHINE_SPI_SLAVE            (1)
 
 // Board specific configurations
-#define MAX_UART             10 // TODO: Change as per bsp?
+#define MAX_UART             2 
 #define MAX_TIMER (32)
+#define MAX_SPI              10 
+#define MAX_I2C              10 
+#define MAX_PWM_OBJS 10 
+#define MICROPY_HW_MAX_I2S 2 

--- a/ports/psoc6/boards/CY8CPROTO-063-BLE/mpconfigboard.h
+++ b/ports/psoc6/boards/CY8CPROTO-063-BLE/mpconfigboard.h
@@ -9,9 +9,9 @@
 #define MICROPY_PY_MACHINE_SPI_SLAVE            (1)
 
 // Board specific configurations
-#define MAX_UART             2 
-#define MAX_TIMER (32)
-#define MAX_SPI              10 
-#define MAX_I2C              10 
-#define MAX_PWM_OBJS 10 
-#define MICROPY_HW_MAX_I2S 2 
+#define MAX_UART              3
+#define MAX_TIMER             32
+#define MAX_SPI               2 
+#define MAX_I2C               3 
+#define MAX_PWM_OBJS          28 
+#define MICROPY_HW_MAX_I2S    1 

--- a/ports/psoc6/machine_i2c.c
+++ b/ports/psoc6/machine_i2c.c
@@ -18,7 +18,6 @@
 #include "machine_pin_phy.h"
 #include "mplogger.h"
 
-#define MAX_I2C              10 // TODO: Change as per bsp?
 #define DEFAULT_I2C_FREQ     (400000)
 #define PSOC_I2C_MASTER_MODE (CYHAL_I2C_MODE_MASTER)
 

--- a/ports/psoc6/machine_i2s.c
+++ b/ports/psoc6/machine_i2s.c
@@ -32,8 +32,6 @@ typedef enum {
     TX
 } i2s_mode_t;
 
-#define MICROPY_HW_MAX_I2S 2 // TODO: Move to per board.
-
 typedef struct _machine_i2s_obj_t {
     mp_obj_base_t base;
     uint8_t i2s_id;     // Private variable in this port case. ID not associated to any port pin i2s group.

--- a/ports/psoc6/machine_pwm.c
+++ b/ports/psoc6/machine_pwm.c
@@ -6,8 +6,6 @@
 #include "machine_pin_phy.h"
 #include "mplogger.h"
 
-#define MAX_PWM_OBJS 10 // TODO: Derive this from BSP
-
 typedef struct _machine_pwm_obj_t {
     mp_obj_base_t base;
     cyhal_pwm_t pwm_obj;

--- a/ports/psoc6/machine_spi.c
+++ b/ports/psoc6/machine_spi.c
@@ -17,8 +17,6 @@
 #include "machine_pin_phy.h"
 #include "mplogger.h"
 
-#define MAX_SPI              10 // TODO: Change as per bsp?
-
 #define DEFAULT_SPI_BAUDRATE    (1000000)
 #define DEFAULT_SPI_POLARITY    (0)
 #define DEFAULT_SPI_PHASE       (0)


### PR DESCRIPTION
- Moved Machine object configs to board-specific files

- Limited the Max of machine objects for each machine class to the actual ones available in that board.