### PR TITLE
Fix external flash fat fs

### DIFF
--- a/ports/psoc6/psoc6_flash.c
+++ b/ports/psoc6/psoc6_flash.c
@@ -200,7 +200,6 @@ static mp_obj_t psoc6_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
 
     if (n_args == 3) {
-        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         uint32_t numSectors = bufinfo.len / FLASH_SECTOR_SIZE;
 
         for (uint32_t i = 0; i <= numSectors; ++i) {
@@ -211,7 +210,6 @@ static mp_obj_t psoc6_flash_writeblocks(size_t n_args, const mp_obj_t *args) {
                 mp_raise_ValueError(MP_ERROR_TEXT("psoc6_flash_writeblocks() - Flash Erase failed !"));
             }
         }
-        MICROPY_END_ATOMIC_SECTION(atomic_state);
     } else {
         offset += mp_obj_get_int(args[3]);
     }

--- a/ports/psoc6/psoc6_qspi_flash.c
+++ b/ports/psoc6/psoc6_qspi_flash.c
@@ -179,7 +179,6 @@ static mp_obj_t psoc6_qspi_flash_writeblocks(size_t n_args, const mp_obj_t *args
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
 
     if (n_args == 3) {
-        mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         uint32_t numSectors = bufinfo.len / EXT_FLASH_SECTOR_SIZE;
 
         for (uint32_t i = 0; i <= numSectors; ++i) {
@@ -191,8 +190,6 @@ static mp_obj_t psoc6_qspi_flash_writeblocks(size_t n_args, const mp_obj_t *args
                 mp_raise_ValueError(MP_ERROR_TEXT("psoc6_qspi_flash_writeblocks() - QSPI flash Erase failed !"));
             }
         }
-
-        MICROPY_END_ATOMIC_SECTION(atomic_state);
     } else {
         offset += mp_obj_get_int(args[3]);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Fix external flash with flash filesystem. -->


### Testing

<!--Test for fat fs is not enabled as the flash is mounted during the initialization with lfs2 as default. Tested locally by changing in main to mount with fat and run the test in flash.py -->



