### PR TITLE
Exit blocking main loop

### DIFF
--- a/docs/psoc6/mpy-usage.rst
+++ b/docs/psoc6/mpy-usage.rst
@@ -149,6 +149,40 @@ Using MicroPython remote control (mpremote) for filesystem operations
 The :ref:`mpremote <mpremote>` tool can be used to transfer files located on the user's host filesystem into the MicroPython filesystem.
 
 
+Resetting the board
+-------------------
+
+If something goes wrong, you can reset the board in two ways. The first is
+to press CTRL-D at the MicroPython prompt, which performs a soft reset.
+
+If that isn't working you can perform a hard reset by pressing the RESET button. 
+This will end your session, disconnecting whatever program (PuTTY, Thonny, etc) that you used to connect to the board.
+
+Boot modes
+----------
+
+There are 2 boot modes:
+
+  * normal boot mode
+  * safe boot mode
+
+boot.py and main.py are executed on "normal boot mode".
+
+boot.py and main.py are *NOT* executed on "safe boot mode".
+
+Changing boot mode :
+
+  * For normal boot mode, just press and release RESET button on the board.
+
+  * For safe boot mode, press and release the RESET button with pressing USER button on the board. Release the USER button after LED on board flashes 2 times.
+
+
+If you change the boot mode to safe boot mode, the MicroPython starts without
+the execution of main.py. Then you can remove the main.py by following command. ::
+    
+    import os
+    os.remove('main.py')
+
 Using third-party IDEs for filesystem operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/psoc6/mpy-usage.rst
+++ b/docs/psoc6/mpy-usage.rst
@@ -166,19 +166,19 @@ There are 2 boot modes:
   * normal boot mode
   * safe boot mode
 
-boot.py and main.py are executed on "normal boot mode".
+``boot.py`` and ``main.py`` are executed on "normal boot mode".
 
-boot.py and main.py are *NOT* executed on "safe boot mode".
+``boot.py`` and ``main.py`` are **not** executed in "safe boot mode".
 
-Changing boot mode :
+Changing boot mode:
 
-  * For normal boot mode, just press and release RESET button on the board.
+  * For normal boot mode, just press and the release RESET button on the board.
 
-  * For safe boot mode, press and release the RESET button with pressing USER button on the board. Release the USER button after LED on board flashes 2 times.
+  * For safe boot mode, press and release the RESET button while pressing the USER button on the board. Release the USER button after the LED on the board flashes twice.
 
 
 If you change the boot mode to safe boot mode, the MicroPython starts without
-the execution of main.py. Then you can remove the main.py by following command. ::
+the execution of ``main.py``. Then you can remove the ``main.py`` by following command: ::
     
     import os
     os.remove('main.py')

--- a/docs/psoc6/mpy-usage.rst
+++ b/docs/psoc6/mpy-usage.rst
@@ -152,27 +152,27 @@ The :ref:`mpremote <mpremote>` tool can be used to transfer files located on the
 Resetting the board
 -------------------
 
-If something goes wrong, you can reset the board in two ways. The first is
-to press CTRL-D at the MicroPython prompt, which performs a soft reset.
+If something goes wrong, you can reset the board in two ways. 
+The first way is to press CTRL-D at the MicroPython prompt, which performs a soft reset.
 
-If that isn't working you can perform a hard reset by pressing the RESET button. 
-This will end your session, disconnecting whatever program (PuTTY, Thonny, etc) that you used to connect to the board.
+If that does not work, you can perform a hard reset by pressing the RESET button. 
+This will end your session, disconnecting whatever program (PuTTY, Thonny, etc.) you used to connect to the board.
 
 Boot modes
 ----------
 
 There are 2 boot modes:
 
-  * normal boot mode
-  * safe boot mode
+  * Normal boot mode
+  * Safe boot mode
 
-``boot.py`` and ``main.py`` are executed on "normal boot mode".
+``boot.py`` and ``main.py`` are executed in "Normal boot mode".
 
-``boot.py`` and ``main.py`` are **not** executed in "safe boot mode".
+``boot.py`` and ``main.py`` are **not** executed in "Safe boot mode".
 
 Changing boot mode:
 
-  * For normal boot mode, just press and the release RESET button on the board.
+  * For normal boot mode, just press and release the RESET button on the board.
 
   * For safe boot mode, press and release the RESET button while pressing the USER button on the board. Release the USER button after the LED on the board flashes twice.
 

--- a/ports/psoc6/main.c
+++ b/ports/psoc6/main.c
@@ -76,7 +76,7 @@ boot_mode_t check_boot_mode(void) {
     cyhal_gpio_init(CYBSP_USER_BTN, CYHAL_GPIO_DIR_INPUT,
         CYHAL_GPIO_DRIVE_PULLUP, CYBSP_BTN_OFF);
 
-    // Added 5ms delay to allow bypass capacitor on the board without external pull-up to charge.
+    // Added 5ms delay to allow bypass capacitor connected to the user button without external pull-up to charge.
     cyhal_system_delay_ms(5);
 
     if (cyhal_gpio_read(CYBSP_USER_BTN) == CYBSP_BTN_PRESSED) {

--- a/ports/psoc6/main.c
+++ b/ports/psoc6/main.c
@@ -44,12 +44,11 @@
 
 #define MPY_TASK_STACK_SIZE                    (4096u)
 #define MPY_TASK_PRIORITY                      (3u)
-#define BUTTON_PRESSED                         (0) // active low
 
 typedef enum {
     BOOT_MODE_NORMAL,
     BOOT_MODE_SAFE
-} BootMode;
+} boot_mode_t;
 
 #if MICROPY_ENABLE_GC
 extern uint8_t __StackTop, __StackLimit;
@@ -66,8 +65,8 @@ void mpy_task(void *arg);
 
 TaskHandle_t mpy_task_handle;
 
-BootMode check_boot_mode(void) {
-    BootMode boot_mode;
+boot_mode_t check_boot_mode(void) {
+    boot_mode_t boot_mode;
 
     // initialize user LED
     cyhal_gpio_init(CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT,
@@ -77,7 +76,7 @@ BootMode check_boot_mode(void) {
     cyhal_gpio_init(CYBSP_USER_BTN, CYHAL_GPIO_DIR_INPUT,
         CYHAL_GPIO_DRIVE_PULLUP, CYBSP_BTN_OFF);
 
-    if (cyhal_gpio_read(CYBSP_USER_BTN) == BUTTON_PRESSED) {
+    if (cyhal_gpio_read(CYBSP_USER_BTN) == CYBSP_BTN_PRESSED) {
         // Blink LED twice to indicate safe boot mode was entered
         for (int i = 0; i < 4; i++)
         {
@@ -85,8 +84,10 @@ BootMode check_boot_mode(void) {
             cyhal_system_delay_ms(500); // delay in millisecond
         }
         boot_mode = BOOT_MODE_SAFE;
+        mp_printf(&mp_plat_print, "- DEVICE IS IN SAFE BOOT MODE -\n");
     } else { // normal boot mode
         boot_mode = BOOT_MODE_NORMAL;
+        mp_printf(&mp_plat_print, "- DEVICE IS IN NORMAL BOOT MODE -\n");
     }
     // free the user LED and user button
     cyhal_gpio_free(CYBSP_USER_BTN);

--- a/ports/psoc6/main.c
+++ b/ports/psoc6/main.c
@@ -76,6 +76,9 @@ boot_mode_t check_boot_mode(void) {
     cyhal_gpio_init(CYBSP_USER_BTN, CYHAL_GPIO_DIR_INPUT,
         CYHAL_GPIO_DRIVE_PULLUP, CYBSP_BTN_OFF);
 
+    // Added 5ms delay to allow bypass capacitor on the board without external pull-up to charge.
+    cyhal_system_delay_ms(5);
+
     if (cyhal_gpio_read(CYBSP_USER_BTN) == CYBSP_BTN_PRESSED) {
         // Blink LED twice to indicate safe boot mode was entered
         for (int i = 0; i < 4; i++)
@@ -87,7 +90,6 @@ boot_mode_t check_boot_mode(void) {
         mp_printf(&mp_plat_print, "- DEVICE IS IN SAFE BOOT MODE -\n");
     } else { // normal boot mode
         boot_mode = BOOT_MODE_NORMAL;
-        mp_printf(&mp_plat_print, "- DEVICE IS IN NORMAL BOOT MODE -\n");
     }
     // free the user LED and user button
     cyhal_gpio_free(CYBSP_USER_BTN);

--- a/tests/ports/psoc6/run_psoc6_tests.sh
+++ b/tests/ports/psoc6/run_psoc6_tests.sh
@@ -145,12 +145,15 @@ run_tests() {
   case ${tests} in *.py)  test_dir_flag="";; esac
 
   ./run-tests.py --target psoc6 --device ${test_dev} ${test_dir_flag} ${tests} ${excluded_tests}
+
+  update_test_result $?
+
   if [ "${debug}" = "true" ]; then
     echo "Running command: ./run-tests.py --print-failures"
     ./run-tests.py --print-failures
   fi
   
-  update_test_result $?
+
 }
 
 mpremote_vfs_large_file_tests() {


### PR DESCRIPTION
### Summary

 Implemented safe boot mode during reset. This allows user to bypass the execution of main.py and boot.py 

### Testing

Only manual test: Add main.py with infinite loop with some print statement, reset and see the print output. Enter into safe mode by pressing both reset and user button on board. release user button after the LED blinks twice. Now the main.py is not executed and can be accessed with file system and modified.


