### PR TITLE
docs/conf.py: Removed get_html_theme_path for rtd conf.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ try:
     import sphinx_rtd_theme
 
     html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
+    html_theme_path = ["."]
 except:
     html_theme = "default"
     html_theme_path = ["."]


### PR DESCRIPTION
https://ifx-micropython.readthedocs.io/en/fix-doc-build/index.html