### PR TITLE
Fix large storage and 063-BLE timer workaround

### DIFF
--- a/tests/ports/psoc6/board_only_hw/multi/network.py
+++ b/tests/ports/psoc6/board_only_hw/multi/network.py
@@ -7,7 +7,6 @@ except ImportError:
     raise SystemExit
 
 channel_new = 1
-ssid_default = "mpy-psoc6-wlan"
 
 
 # Access Point
@@ -17,7 +16,12 @@ def instance0():
 
     ap_if = network.WLAN(network.AP_IF)
     print("ap instance created")
-    ap_if.config(channel=channel_new)
+
+    # Generate "random" SSID to avoid test conflicts
+    time_stamp = time.time()
+    ssid_new = "mpy-psoc6-" + str(time_stamp)
+    multitest.globals(ssid_gen=ssid_new)
+    ap_if.config(channel=channel_new, ssid=ssid_new)
 
     # active()
     print("ap initially not active: ", ap_if.active() == False)
@@ -62,11 +66,13 @@ def instance1():
 
     # scan()
     wlan_nets = sta_if.scan()
-    test_ap_net = [net for net in wlan_nets if net[0] == b"mpy-psoc6-wlan"]
+    # The returned ssid is a bytes object
+    bytes_ssid = bytes(ssid_gen, "utf-8")
+    test_ap_net = [net for net in wlan_nets if net[0] == bytes_ssid]
     print("sta scan finds ap wlan: ", test_ap_net != [])
 
-    wlan_ssid_filter = sta_if.scan(ssid="mpy-psoc6-wlan")
-    test_ap_net = [net for net in wlan_ssid_filter if net[0] == b"mpy-psoc6-wlan"]
+    wlan_ssid_filter = sta_if.scan(ssid=ssid_gen)
+    test_ap_net = [net for net in wlan_ssid_filter if net[0] == bytes_ssid]
     print("sta scan finds ap wlan (ssid filter): ", test_ap_net != [])
 
     # print('ap_mac: ', binascii.hexlify(ap_mac, ':'))
@@ -79,7 +85,7 @@ def instance1():
     print("sta is not (yet) connected: ", sta_if.isconnected() == False)
 
     # connect()
-    sta_if.connect(ssid_default, "mpy_PSOC6_w3lc0me!")
+    sta_if.connect(ssid_gen, "mpy_PSOC6_w3lc0me!")
     print("sta attempt connection to ap")
 
     # active()
@@ -100,6 +106,6 @@ def instance1():
     print("sta is disconnected: ", sta_if.active() == False)
 
     print("sta attempt connection to ap (with bssid)")
-    sta_if.connect(ssid_default, "mpy_PSOC6_w3lc0me!", bssid=ap_mac)
+    sta_if.connect(ssid_gen, "mpy_PSOC6_w3lc0me!", bssid=ap_mac)
 
     print("sta is active: ", sta_if.active() == True)

--- a/tests/ports/psoc6/board_only_hw/multi/network_config.py
+++ b/tests/ports/psoc6/board_only_hw/multi/network_config.py
@@ -1,4 +1,5 @@
 import binascii, time
+import random
 
 try:
     import network
@@ -6,8 +7,7 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-channel_new = 5
-ssid_new = "mpy-test-conf-wlan"
+channel_new = random.randint(1, 5)
 pass_new = "alicessecret"
 sec_new = network.WLAN.WPA2
 
@@ -26,8 +26,14 @@ def instance0():
     # get config()
     ap_if.config(channel=channel_new)
     print("ap config get channel: ", ap_if.config("channel") == channel_new)
+
+    # Generate "random" SSID to avoid test conflicts
+    time_stamp = time.time()
+    ssid_new = "mpy-test-" + str(time_stamp)
+    multitest.globals(ssid_gen=ssid_new)
     ap_if.config(ssid=ssid_new)
     print("ap config get ssid: ", ap_if.config("ssid") == ssid_new)
+
     ap_if.config(security=sec_new, key=pass_new)
     print("ap config get security: ", ap_if.config("security") == sec_new)
     try:
@@ -67,7 +73,7 @@ def instance1():
     print("sta instance created")
 
     # connect()
-    sta_if.connect(ssid_new, pass_new)
+    sta_if.connect(ssid_gen, pass_new)
     print("sta attempt connection to ap")
 
     # active()
@@ -78,7 +84,7 @@ def instance1():
 
     # config()
     print("sta assoc ap channel config: ", sta_if.config("channel") == channel_new)
-    print("sta assoc ap ssid config: ", sta_if.config("ssid") == ssid_new)
+    print("sta assoc ap ssid config: ", sta_if.config("ssid") == ssid_gen)
     print("sta assoc ap security config: ", sta_if.config("security") == sec_new)
 
     try:

--- a/tests/ports/psoc6/board_only_hw/single/timer.py
+++ b/tests/ports/psoc6/board_only_hw/single/timer.py
@@ -1,3 +1,4 @@
+import os
 from machine import Timer
 import time
 
@@ -76,3 +77,11 @@ if __name__ == "__main__":
     test_periodic()
     print("*****Multiple Timers Execution*****")
     test_multiple_timers()
+
+    # TODO: Timer tests need to be refined.
+    # The current implementation is not reliable.
+    # After this tests CY8CPROTO-063-BLE board is not able to the subsequent test.
+    # This workaround works for
+    board = os.uname().machine
+    if "CY8CPROTO-063-BLE" in board:
+        time.sleep(3)

--- a/tests/ports/psoc6/mp_custom/fs.py
+++ b/tests/ports/psoc6/mp_custom/fs.py
@@ -1,6 +1,10 @@
 import subprocess
 import sys
 import os
+import logging
+
+logger = logging.getLogger("fs")
+logging.basicConfig(format="%(levelname)s: %(message)s", encoding="utf-8", level=logging.WARNING)
 
 device = sys.argv[1]
 test_type = sys.argv[2]
@@ -24,6 +28,8 @@ def set_mpr_run_script(mem_type):
     if mem_type == "sd":
         mpr_run_script = f"run {test_script_dir}/fs_mount_sd.py"
 
+    logger.debug(f'Set setup script command to: "{mpr_run_script}"')
+
 
 def set_remote_dir_path(mem_type):
     # Set test directory path based on the memory type
@@ -32,6 +38,8 @@ def set_remote_dir_path(mem_type):
         remote_directory_path = "/sd/"
     else:
         remote_directory_path = "/"
+
+    logger.debug(f'Set remote path to : "{mpr_run_script}"')
 
 
 def get_test_input_files(test_type):
@@ -57,27 +65,35 @@ def get_test_name(test_type, mem_type):
     elif mem_type == "flash":
         mem_type_suffix = ""
 
+    logger.debug(f"Get tests name : fs_{test_type}{mem_type_suffix}.py")
+
     return f"fs_{test_type}{mem_type_suffix}.py"
 
 
 def ls_files(files):
+    logger.debug(f"ls_files input: {files}")
     # It will return an array with the file size found in the remote directory
     # If -1, the file was not found
     mpr_ls = f"{mpr_connect} {mpr_run_script} fs ls {remote_directory_path}"
+    logger.debug(f"ls_files command: {mpr_ls}")
     output = subprocess.run(f"{mpr_ls}", shell=True, capture_output=True)
 
     files_result = []
-    lines = output.stdout.decode().split("\r\n")
+    lines = output.stdout.decode().split("\n")
+    logger.debug(f"ls_files output lines: {lines}")
 
     for file in files:
         file_size = -1
         for line in lines:
             line = line.split()
+            logger.debug(f"ls_files current processed line: {line}")
             if file in line:
                 file_size = line[0]
+                logger.debug(f"ls_files found file: {file} with size {file_size}")
 
         files_result.append(file_size)
 
+    logger.debug(f"ls_files result: {files_result}")
     return files_result
 
 
@@ -86,6 +102,8 @@ def rm_files(files):
     # The command will be concatenated with the files to remove. Example:
     # ../tools/mpremote/mpremote.py connect /dev/ttyACM0 fs rm /test_fs_medium_file.txt + fs rm /test_fs_medium_file.txt
     mpr_rm = f"{mpr_connect} {mpr_run_script} fs rm "
+
+    logger.debug(f"rm_files command: {mpr_rm}")
 
     rm_sub_cmd = ""
     last_file = files[-1]
@@ -96,11 +114,16 @@ def rm_files(files):
 
         rm_sub_cmd += f"fs rm {remote_directory_path}{file}{append_cmd_operand}"
 
-    subprocess.run(f"{mpr_connect} {mpr_run_script} {rm_sub_cmd}", shell=True, capture_output=True)
+    mpr_rm_cmd = f"{mpr_connect} {mpr_run_script} {rm_sub_cmd}"
+
+    logger.debug(f"rm_files command: {mpr_rm_cmd}")
+
+    subprocess.run(f"{mpr_rm_cmd}", shell=True, capture_output=True)
 
 
 def rm_files_if_exist(files):
     matches = ls_files(files)
+    logger.debug(f"Files (to be removed) found: {matches}")
 
     # Take only the files that which sizes are not -1 (the existing files in the remote directory)
     existing_files = []
@@ -108,11 +131,14 @@ def rm_files_if_exist(files):
         if matches[i] != -1:
             existing_files.append(files[i])
 
+    logger.debug(f"Existing (to be removed) files: {existing_files}")
+
     # Remove any found input files in the remote directory
     if existing_files != []:
         print(f"Removing existing files...")
         rm_files(existing_files)
-        if ls_files(files) == [-1 for _ in range(len(files))]:
+        matches = ls_files(files)
+        if matches == [-1 for _ in range(len(files))]:
             print(f"Existing files removed.")
 
 
@@ -129,6 +155,8 @@ def copy_files(input_cp_files):
 
     cp_cmd = f"{mpr_connect} {mpr_run_script} {cp_sub_cmd}"
 
+    logger.debug(f"cp_files command: {cp_cmd}")
+
     subprocess.run(cp_cmd, shell=True, capture_output=True)
 
 
@@ -136,6 +164,8 @@ def validate_test(files, file_sizes):
     # This function will validate the test by comparing the file sizes found with ls
     # in the remote directory with the expected file sizes
     found_sizes = ls_files(files)
+
+    logger.debug(f"Found sizes: {found_sizes}")
 
     if found_sizes != file_sizes:
         msg = "fail"


### PR DESCRIPTION
* Changes in line ending of mpremote made the fs tests fail --> Fixed now (and added some debug logger traces.)
* Timer test and module is behind failure of the subsequent test --> Added workaround with time.sleep
* Randomize ssid and channels to reduce connection issues in tests.

