### PR TITLE
tools/ : Add psoc6 port for code-size-diff check.

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -16,6 +16,7 @@ on:
       - 'ports/samd/**'
       - 'ports/stm32/**'
       - 'ports/unix/**'
+      - 'ports/psoc6/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -11,7 +11,6 @@ endif
 # Get active board from mtb-lib previous runs
 # The board is set only after make mtb_init 
 # has been run. 
-$(info BOARD : $(BOARD))
 ifeq ($(BOARD),)
     ifeq ($(ACTIVE_BOARD),)
         $(error ModusToolbox not initialized. Run "make mtb_init BOARD=<target-board>" to configure the environment. )
@@ -220,7 +219,6 @@ include mtb-libs/makefile_mtb.mk
 MPY_CROSS_FLAGS += -march=armv7m
 
 build_code_size: 
-$(info MAKECMDGOALS: $(MAKECMDGOALS))
 ifeq ($(filter clean,$(MAKECMDGOALS)),clean)
 build_code_size: clean
 else

--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -11,6 +11,7 @@ endif
 # Get active board from mtb-lib previous runs
 # The board is set only after make mtb_init 
 # has been run. 
+$(info BOARD : $(BOARD))
 ifeq ($(BOARD),)
     ifeq ($(ACTIVE_BOARD),)
         $(error ModusToolbox not initialized. Run "make mtb_init BOARD=<target-board>" to configure the environment. )
@@ -218,9 +219,17 @@ include mtb-libs/makefile_mtb.mk
 
 MPY_CROSS_FLAGS += -march=armv7m
 
+build_code_size: 
+$(info MAKECMDGOALS: $(MAKECMDGOALS))
+ifeq ($(filter clean,$(MAKECMDGOALS)),clean)
+build_code_size: clean
+else
+build_code_size: mtb_init all
+endif
+
 build: mtb_get_build_flags $(GENERATED_PINS) $(BUILD)/firmware.hex
 
-all: mtb_init build
+all: build
 
 clean: mtb_clean
 
@@ -309,7 +318,7 @@ help:
 	$(info - mtb_set_bsp             Set the board as active in the ModusToolbox project. ) 
 
 
-.PHONY: build test test_multi program_multi help
+.PHONY: build test test_multi program_multi help build_code_size
 
 # include py core make definitions
 include $(TOP)/py/mkrules.mk

--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -223,6 +223,7 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),clean)
 build_code_size: clean
 else
 build_code_size: mtb_init all
+	$(shell source tools/psoc6/dev-setup.sh)
 endif
 
 build: mtb_get_build_flags $(GENERATED_PINS) $(BUILD)/firmware.hex

--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -220,7 +220,7 @@ MPY_CROSS_FLAGS += -march=armv7m
 
 build: mtb_get_build_flags $(GENERATED_PINS) $(BUILD)/firmware.hex
 
-all: build
+all: mtb_init build
 
 clean: mtb_clean
 

--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -223,7 +223,7 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),clean)
 build_code_size: clean
 else
 build_code_size: mtb_init all
-	$(shell source tools/psoc6/dev-setup.sh)
+	@bash -c "source tools/psoc6/dev-setup.sh && make mtb_init && make all"
 endif
 
 build: mtb_get_build_flags $(GENERATED_PINS) $(BUILD)/firmware.hex

--- a/ports/psoc6/Makefile
+++ b/ports/psoc6/Makefile
@@ -223,7 +223,7 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),clean)
 build_code_size: clean
 else
 build_code_size: mtb_init all
-	@bash -c "source tools/psoc6/dev-setup.sh && make mtb_init && make all"
+	@bash -c "source ../../tools/psoc6/dev-setup.sh && make mtb_init && make all"
 endif
 
 build: mtb_get_build_flags $(GENERATED_PINS) $(BUILD)/firmware.hex

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -66,7 +66,7 @@ function ci_code_size_setup {
 
 function ci_code_size_build {
     # check the following ports for the change in their code size
-    PORTS_TO_CHECK=bmusxpdv
+    PORTS_TO_CHECK=i
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # Default GitHub pull request sets HEAD to a generated merge commit

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -64,6 +64,7 @@ function ci_code_size_setup {
     ci_gcc_riscv_setup
 }
 
+
 function ci_code_size_build {
     # check the following ports for the change in their code size
     PORTS_TO_CHECK=ibmusxpdv

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -66,7 +66,7 @@ function ci_code_size_setup {
 
 function ci_code_size_build {
     # check the following ports for the change in their code size
-    PORTS_TO_CHECK=i
+    PORTS_TO_CHECK=ibmusxpdv
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # Default GitHub pull request sets HEAD to a generated merge commit

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -59,7 +59,7 @@ class PortData:
 
 port_data = {
     "i": PortData(
-        "psoc6", "psoc6/", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]
+        "psoc6", "psoc6", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]
     ),
     "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
     "m": PortData("minimal x86", "minimal", "build/firmware.elf"),

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -45,7 +45,7 @@ Other commands:
 
 import collections, sys, re, subprocess
 
-MAKE_FLAGS = ["-j3", "CFLAGS_EXTRA=-DNDEBUG"]
+MAKE_FLAGS = []  # ["-j3", "CFLAGS_EXTRA=-DNDEBUG"]
 
 
 class PortData:
@@ -58,20 +58,21 @@ class PortData:
 
 
 port_data = {
-    "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
-    "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
-    "u": PortData("unix x64", "unix", "build-standard/micropython"),
-    "n": PortData("unix nanbox", "unix", "build-nanbox/micropython", "VARIANT=nanbox"),
-    "s": PortData("stm32", "stm32", "build-PYBV10/firmware.elf", "BOARD=PYBV10"),
-    "c": PortData("cc3200", "cc3200", "build/WIPY/release/application.axf", "BTARGET=application"),
-    "8": PortData("esp8266", "esp8266", "build-ESP8266_GENERIC/firmware.elf"),
-    "3": PortData("esp32", "esp32", "build-ESP32_GENERIC/micropython.elf"),
-    "x": PortData("mimxrt", "mimxrt", "build-TEENSY40/firmware.elf"),
-    "e": PortData("renesas-ra", "renesas-ra", "build-EK_RA6M2/firmware.elf"),
-    "r": PortData("nrf", "nrf", "build-PCA10040/firmware.elf"),
-    "p": PortData("rp2", "rp2", "build-RPI_PICO_W/firmware.elf", "BOARD=RPI_PICO_W"),
-    "d": PortData("samd", "samd", "build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf"),
-    "v": PortData("qemu rv32", "qemu", "build-VIRT_RV32/firmware.elf", "BOARD=VIRT_RV32"),
+    "i": PortData("psoc6", "psoc6", "build/firmware.elf", "BOARD=CY8CPROTO-062-4343W"),
+    # "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
+    # "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
+    # "u": PortData("unix x64", "unix", "build-standard/micropython"),
+    # "n": PortData("unix nanbox", "unix", "build-nanbox/micropython", "VARIANT=nanbox"),
+    # "s": PortData("stm32", "stm32", "build-PYBV10/firmware.elf", "BOARD=PYBV10"),
+    # "c": PortData("cc3200", "cc3200", "build/WIPY/release/application.axf", "BTARGET=application"),
+    # "8": PortData("esp8266", "esp8266", "build-ESP8266_GENERIC/firmware.elf"),
+    # "3": PortData("esp32", "esp32", "build-ESP32_GENERIC/micropython.elf"),
+    # "x": PortData("mimxrt", "mimxrt", "build-TEENSY40/firmware.elf"),
+    # "e": PortData("renesas-ra", "renesas-ra", "build-EK_RA6M2/firmware.elf"),
+    # "r": PortData("nrf", "nrf", "build-PCA10040/firmware.elf"),
+    # "p": PortData("rp2", "rp2", "build-RPI_PICO_W/firmware.elf", "BOARD=RPI_PICO_W"),
+    # "d": PortData("samd", "samd", "build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf"),
+    # "v": PortData("qemu rv32", "qemu", "build-VIRT_RV32/firmware.elf", "BOARD=VIRT_RV32"),
 }
 
 

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -58,9 +58,7 @@ class PortData:
 
 
 port_data = {
-    "i": PortData(
-        "psoc6", "psoc6/", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]
-    ),
+    "i": PortData("psoc6", "psoc6/", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]),
     "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
     "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
     "u": PortData("unix x64", "unix", "build-standard/micropython"),

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -58,21 +58,23 @@ class PortData:
 
 
 port_data = {
-    "i": PortData("psoc6", "psoc6", "build/firmware.elf", "BOARD=CY8CPROTO-062-4343W"),
-    # "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
-    # "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
-    # "u": PortData("unix x64", "unix", "build-standard/micropython"),
-    # "n": PortData("unix nanbox", "unix", "build-nanbox/micropython", "VARIANT=nanbox"),
-    # "s": PortData("stm32", "stm32", "build-PYBV10/firmware.elf", "BOARD=PYBV10"),
-    # "c": PortData("cc3200", "cc3200", "build/WIPY/release/application.axf", "BTARGET=application"),
-    # "8": PortData("esp8266", "esp8266", "build-ESP8266_GENERIC/firmware.elf"),
-    # "3": PortData("esp32", "esp32", "build-ESP32_GENERIC/micropython.elf"),
-    # "x": PortData("mimxrt", "mimxrt", "build-TEENSY40/firmware.elf"),
-    # "e": PortData("renesas-ra", "renesas-ra", "build-EK_RA6M2/firmware.elf"),
-    # "r": PortData("nrf", "nrf", "build-PCA10040/firmware.elf"),
-    # "p": PortData("rp2", "rp2", "build-RPI_PICO_W/firmware.elf", "BOARD=RPI_PICO_W"),
-    # "d": PortData("samd", "samd", "build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf"),
-    # "v": PortData("qemu rv32", "qemu", "build-VIRT_RV32/firmware.elf", "BOARD=VIRT_RV32"),
+    "i": PortData(
+        "psoc6", "psoc6/", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]
+    ),
+    "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
+    "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
+    "u": PortData("unix x64", "unix", "build-standard/micropython"),
+    "n": PortData("unix nanbox", "unix", "build-nanbox/micropython", "VARIANT=nanbox"),
+    "s": PortData("stm32", "stm32", "build-PYBV10/firmware.elf", "BOARD=PYBV10"),
+    "c": PortData("cc3200", "cc3200", "build/WIPY/release/application.axf", "BTARGET=application"),
+    "8": PortData("esp8266", "esp8266", "build-ESP8266_GENERIC/firmware.elf"),
+    "3": PortData("esp32", "esp32", "build-ESP32_GENERIC/micropython.elf"),
+    "x": PortData("mimxrt", "mimxrt", "build-TEENSY40/firmware.elf"),
+    "e": PortData("renesas-ra", "renesas-ra", "build-EK_RA6M2/firmware.elf"),
+    "r": PortData("nrf", "nrf", "build-PCA10040/firmware.elf"),
+    "p": PortData("rp2", "rp2", "build-RPI_PICO_W/firmware.elf", "BOARD=RPI_PICO_W"),
+    "d": PortData("samd", "samd", "build-ADAFRUIT_ITSYBITSY_M4_EXPRESS/firmware.elf"),
+    "v": PortData("qemu rv32", "qemu", "build-VIRT_RV32/firmware.elf", "BOARD=VIRT_RV32"),
 }
 
 
@@ -84,6 +86,7 @@ def syscmd(*args):
             a2.append(a)
         elif a:
             a2.extend(a)
+    print("Executing command:", " ".join(a2))
     subprocess.check_call(a2)
 
 

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -45,7 +45,7 @@ Other commands:
 
 import collections, sys, re, subprocess
 
-MAKE_FLAGS = []  # ["-j3", "CFLAGS_EXTRA=-DNDEBUG"]
+MAKE_FLAGS = ["-j3", "CFLAGS_EXTRA=-DNDEBUG"]
 
 
 class PortData:
@@ -58,7 +58,9 @@ class PortData:
 
 
 port_data = {
-    "i": PortData("psoc6", "psoc6/", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]),
+    "i": PortData(
+        "psoc6", "psoc6/", "build/firmware.elf", ["build_code_size", "BOARD=CY8CPROTO-062-4343W"]
+    ),
     "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
     "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
     "u": PortData("unix x64", "unix", "build-standard/micropython"),
@@ -84,7 +86,6 @@ def syscmd(*args):
             a2.append(a)
         elif a:
             a2.extend(a)
-    print("Executing command:", " ".join(a2))
     subprocess.check_call(a2)
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary
Enable psoc6 port in  code-size-diff workflow to be able to track code size changes with every PR.


### Testing
Depends on **_tools/metrics.py_**. To test locally:
1. Checkout to ports-psoc6-main:

`./tools/metrics.py build | tee size0` 

2. Switch to feature-branch and run:

`./tools/metrics.py build | tee size1`
`./tools/metrics.py diff size0 size1`

3. To print current size:

`./tools/metrics.py sizes i `

