### PR TITLE
PSOC6 port setup improvements

### DIFF
--- a/ports/psoc6/README.md
+++ b/ports/psoc6/README.md
@@ -16,6 +16,11 @@ If the ModusToolbox™ has not been installed in the default path (`~/ModusToolb
 
     source tools/psoc6/dev-setup.sh && toolchain_setup [mtb_path]
 
+### MacOS
+
+> [!NOTE]  
+> If you are using MacOS, you need to install GNU make. The default make on Mac OS is BSD make, which is not compatible with the Makefile used in this port. Remember to add GNU make to the system path PATH.
+
 ## Building and running Linux version
 
 As we are working on the ports-psoc6-main branch (for now), first checkout that branch after cloning this repo:

--- a/tools/psoc6/dev-setup.sh
+++ b/tools/psoc6/dev-setup.sh
@@ -10,7 +10,7 @@
 
 function set_mtb_tools_path {
     mtb_path=$1
-    if [ "$mtb_path" = "" ]; then
+    if [ -z "$mtb_path" ]; then
         mtb_path=~/ModusToolbox
     fi
     
@@ -18,19 +18,19 @@ function set_mtb_tools_path {
 }
 
 function export_path {
-    mtb_tools_path=$(set_mtb_tools_path)
+    mtb_tools_path=$(set_mtb_tools_path "$1")
     export PATH=${mtb_tools_path}/openocd/bin:${mtb_tools_path}/library-manager:${mtb_tools_path}/fw-loader/bin/:${mtb_tools_path}/gcc/bin:$PATH
 }
 
 function install_udev_rules {
-    mtb_tools_path=$(set_mtb_tools_path)
-    ${mtb_tools_path}/openocd/udev_rules/install_rules.sh
+    mtb_tools_path=$(set_mtb_tools_path "$1")
+    test -f ${mtb_tools_path}/openocd/udev_rules/install_rules.sh && ${mtb_tools_path}/openocd/udev_rules/install_rules.sh
 }
 
 function toolchain_setup {
     mtb_path=$1
     export_path ${mtb_path}
-    install_udev_rules
+    install_udev_rules ${mtb_path}
 }
 
 function git_add_ssh {


### PR DESCRIPTION
* Added notes for installation on macOS.
* Fixed dev-setup.sh script for non-default MTB installation path.

