### PR TITLE
github/workflows/ports_psoc6.yml: No continue on error for notification.

### DIFF
--- a/.github/workflows/ports_psoc6.yml
+++ b/.github/workflows/ports_psoc6.yml
@@ -49,7 +49,6 @@ jobs:
     if: github.repository_owner == 'infineon'
     runs-on: self-hosted
     needs: server-build
-    continue-on-error: true
     strategy:
       matrix:
         board:


### PR DESCRIPTION
After some research, I think this is the flag letting the CI green and thus not sending the notifications.
Let´s check.

This was convenient as when we could see at least one board working, we could point out to certain HIL limitations and lack of robustness. 
But this way we are more strict, so even better quality-wise.

